### PR TITLE
IRBuilder: Mark nodes without successors as `Exit` kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--dump-config` CLI flag that dumps the Misti configuration file in use: PR [#79](https://github.com/nowarp/misti/pull/79)
 
 ### Changed
+- IRBuilder: Mark nodes without successors as `Exit` kind: PR [#80](https://github.com/nowarp/misti/pull/80)
 
 ### Fixed
 - Set the actual documentation URL in warnings.

--- a/src/internals/ir.ts
+++ b/src/internals/ir.ts
@@ -433,9 +433,9 @@ export type NodeKind =
    */
   | { kind: "call"; callees: Set<CFGIdx> }
   /**
-   * Represents a return node that effectively terminates the execution of the current control flow.
+   * Represents an exit node that effectively terminates the execution of the current control flow.
    */
-  | { kind: "return" };
+  | { kind: "exit" };
 
 /**
  * Represents a node in a Control Flow Graph (CFG), corresponding to a single statement in the source code.
@@ -461,7 +461,7 @@ export class Node {
    * Returns true iff this basic block terminates control flow.
    */
   public isExit(): boolean {
-    return this.kind.kind === "return";
+    return this.kind.kind === "exit";
   }
 }
 

--- a/src/internals/irDump.ts
+++ b/src/internals/irDump.ts
@@ -76,8 +76,7 @@ export class GraphvizDumper {
       output += `        color=lightgrey;\n`;
     }
     cfg.forEachNode(cu.ast, (stmt, node) => {
-      const color =
-        node.kind.kind === "return" ? ',style=filled,fillcolor="#66A7DB"' : "";
+      const color = node.isExit() ? ',style=filled,fillcolor="#66A7DB"' : "";
       output += `        "${prefix}_${node.idx}" [label="${this.ppSummary(stmt)}"${color}];\n`;
     });
     cfg.forEachEdge((edge) => {

--- a/test/good/messages-1.cfg.dot
+++ b/test/good/messages-1.cfg.dot
@@ -3,11 +3,11 @@ digraph "messages-1" {
     subgraph "cluster_A__receive_internal_comment_1561_increment" {
         label="A__receive_internal_comment_1561_increment";
         "A__receive_internal_comment_1561_increment_142" [label="self.val = self.val + 1"];
-        "A__receive_internal_comment_1561_increment_143" [label="self.reply(M{value: self.val}.toCell())"];
+        "A__receive_internal_comment_1561_increment_143" [label="self.reply(M{value: self.val}.toCell())",style=filled,fillcolor="#66A7DB"];
         "A__receive_internal_comment_1561_increment_142" -> "A__receive_internal_comment_1561_increment_143";
     }
     subgraph "cluster_A__receive_internal_comment_1576_query" {
         label="A__receive_internal_comment_1576_query";
-        "A__receive_internal_comment_1576_query_145" [label="self.reply(M{value: self.val}.toCell())"];
+        "A__receive_internal_comment_1576_query_145" [label="self.reply(M{value: self.val}.toCell())",style=filled,fillcolor="#66A7DB"];
     }
 }

--- a/test/good/never-accessed-2.cfg.dot
+++ b/test/good/never-accessed-2.cfg.dot
@@ -2,7 +2,7 @@ digraph "never-accessed-2" {
     node [shape=box];
     subgraph "cluster_FieldTest__init_1549" {
         label="FieldTest__init_1549";
-        "FieldTest__init_1549_142" [label="self.f1 = sender()"];
+        "FieldTest__init_1549_142" [label="self.f1 = sender()",style=filled,fillcolor="#66A7DB"];
     }
     subgraph "cluster_FieldTest__use_f1" {
         label="FieldTest__use_f1";

--- a/test/good/never-accessed-3.cfg.dot
+++ b/test/good/never-accessed-3.cfg.dot
@@ -2,6 +2,6 @@ digraph "never-accessed-3" {
     node [shape=box];
     subgraph "cluster_FieldTest__init_1537" {
         label="FieldTest__init_1537";
-        "FieldTest__init_1537_141" [label="self.f1 = sender()"];
+        "FieldTest__init_1537_141" [label="self.f1 = sender()",style=filled,fillcolor="#66A7DB"];
     }
 }

--- a/test/good/never-accessed-4.cfg.dot
+++ b/test/good/never-accessed-4.cfg.dot
@@ -2,6 +2,6 @@ digraph "never-accessed-4" {
     node [shape=box];
     subgraph "cluster_ConstantFieldTest__test" {
         label="ConstantFieldTest__test";
-        "ConstantFieldTest__test_141" [label="send(SendParameters{to: sender(), bounce: true, value: self.val, mode: SendRemainingValue + SendIgnoreErrors})"];
+        "ConstantFieldTest__test_141" [label="send(SendParameters{to: sender(), bounce: true, value: self.val, mode: SendRemainingValue + SendIgnoreErrors})",style=filled,fillcolor="#66A7DB"];
     }
 }

--- a/test/good/never-accessed-8.cfg.dot
+++ b/test/good/never-accessed-8.cfg.dot
@@ -1,0 +1,7 @@
+digraph "never-accessed-8" {
+    node [shape=box];
+    subgraph "cluster_TestContract__receive_internal_fallback_1531" {
+        label="TestContract__receive_internal_fallback_1531";
+        "TestContract__receive_internal_fallback_1531_141" [label="let test: Int = 123",style=filled,fillcolor="#66A7DB"];
+    }
+}

--- a/test/good/never-accessed-8.cfg.json
+++ b/test/good/never-accessed-8.cfg.json
@@ -1,0 +1,25 @@
+{
+  "projectName": "never-accessed-8",
+  "functions": [],
+  "contracts": [
+    {
+      "name": "TestContract",
+      "methods": [
+        {
+          "name": "TestContract.receive_internal_fallback_1531",
+          "cfg": {
+            "nodes": [
+              {
+                "id": 141,
+                "stmtID": 1530,
+                "srcEdges": [],
+                "dstEdges": []
+              }
+            ],
+            "edges": []
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/good/never-accessed-8.expected.out
+++ b/test/good/never-accessed-8.expected.out
@@ -1,0 +1,8 @@
+test/good/never-accessed-8.tact:3:9:
+  2 |     receive() {
+> 3 |         let test: Int = 123; // should be reported
+              ^
+  4 |     }
+Variable is never accessed
+Help: Consider removing the variable
+See: https://nowarp.github.io/tools/misti/docs/detectors/NeverAccessedVariables

--- a/test/good/never-accessed-8.tact
+++ b/test/good/never-accessed-8.tact
@@ -1,0 +1,5 @@
+contract TestContract {
+    receive() {
+        let test: Int = 123; // should be reported
+    }
+}

--- a/test/good/readonly-3.cfg.dot
+++ b/test/good/readonly-3.cfg.dot
@@ -3,7 +3,7 @@ digraph "readonly-3" {
     subgraph "cluster_test" {
         label="test";
         "test_141" [label="let a: Int = 42"];
-        "test_142" [label="if (a == 42)"];
+        "test_142" [label="if (a == 42)",style=filled,fillcolor="#66A7DB"];
         "test_141" -> "test_142";
     }
 }

--- a/test/good/readonly-4.cfg.dot
+++ b/test/good/readonly-4.cfg.dot
@@ -3,7 +3,7 @@ digraph "readonly-4" {
     subgraph "cluster_test" {
         label="test";
         "test_141" [label="let a: Int = 10"];
-        "test_142" [label="if (a == 42)"];
+        "test_142" [label="if (a == 42)",style=filled,fillcolor="#66A7DB"];
         "test_141" -> "test_142";
     }
 }

--- a/test/good/string-literals.cfg.dot
+++ b/test/good/string-literals.cfg.dot
@@ -2,6 +2,6 @@ digraph "string-literals" {
     node [shape=box];
     subgraph "cluster_test" {
         label="test";
-        "test_141" [label="require(true, \"Invalid value\")"];
+        "test_141" [label="require(true, \"Invalid value\")",style=filled,fillcolor="#66A7DB"];
     }
 }

--- a/test/good/zero-address.cfg.dot
+++ b/test/good/zero-address.cfg.dot
@@ -2,6 +2,6 @@ digraph "zero-address" {
     node [shape=box];
     subgraph "cluster_SampleContract__init_1533" {
         label="SampleContract__init_1533";
-        "SampleContract__init_1533_141" [label="newAddress(1, 0)"];
+        "SampleContract__init_1533_141" [label="newAddress(1, 0)",style=filled,fillcolor="#66A7DB"];
     }
 }


### PR DESCRIPTION
Closes #76

- [x] I have updated `CHANGELOG.md`
- [x] I have added tests to demonstrate the contribution is correctly implemented
- [x] No test failures were reported when running `yarn test-all`
- [x] I did not do unrelated and/or undiscussed refactorings

