### PR TITLE
IR: Improve `ImportGraph` functionality; refactor `AstStore`

### DIFF
--- a/src/internals/ir/astStore.ts
+++ b/src/internals/ir/astStore.ts
@@ -520,6 +520,8 @@ export class TactASTStore {
         case "trait":
           result.push(...Array.from(this.getTraits(params)));
           break;
+        default:
+          break;
       }
     }
     return params.filename

--- a/src/internals/ir/astStore.ts
+++ b/src/internals/ir/astStore.ts
@@ -508,10 +508,10 @@ export class TactASTStore {
       : result;
   }
 
-  public fileMatches = (node: { loc: SrcInfo }, filename: string): boolean =>
+  private fileMatches = (node: { loc: SrcInfo }, filename: string): boolean =>
     node.loc.file !== null && node.loc.file === filename;
 
-  public *filterIterator<T>(
+  private *filterIterator<T>(
     iterator: IterableIterator<T>,
     condition: (item: T) => boolean,
   ): IterableIterator<T> {

--- a/src/internals/ir/astStore.ts
+++ b/src/internals/ir/astStore.ts
@@ -2,6 +2,7 @@ import { InternalException } from "../exceptions";
 import {
   AstAsmFunctionDef,
   AstConstantDef,
+  AstModule,
   AstContract,
   SrcInfo,
   AstContractInit,
@@ -22,6 +23,8 @@ export type AstItemParams = Partial<{
   filename: string | undefined;
 }>;
 
+type Filename = string;
+
 /**
  * Provides access to AST elements defined within a single Tact project.
  *
@@ -35,7 +38,7 @@ export class TactASTStore {
    *
    * @param stdlibIds Identifiers of AST elements defined in stdlib.
    * @param contractConstants Identifiers of constants defined within contracts.
-   * @param programEntries Identifiers of AST elements defined on the top-level.
+   * @param programEntries Identifiers of AST elements defined on the top-level of each file.
    * @param functions Functions and methods including user-defined and special methods.
    * @param constants Constants defined across the compilation unit.
    * @param contracts Contracts defined within the project.
@@ -48,55 +51,57 @@ export class TactASTStore {
    * @param statements All executable statements within all functions of the project.
    */
   constructor(
-    private stdlibIds = new Set<number>(),
-    private contractConstants = new Set<number>(),
-    private programEntries: Set<number>,
+    private stdlibIds = new Set<AstNode["id"]>(),
+    private contractConstants = new Set<AstNode["id"]>(),
+    private programEntries: Map<Filename, Set<AstNode["id"]>>,
     private functions: Map<
-      number,
+      AstNode["id"],
       AstFunctionDef | AstReceiver | AstContractInit
     >,
-    private constants: Map<number, AstConstantDef>,
-    private contracts: Map<number, AstContract>,
-    private nativeFunctions: Map<number, AstNativeFunctionDecl>,
-    private asmFunctions: Map<number, AstAsmFunctionDef>,
-    private primitives: Map<number, AstPrimitiveTypeDecl>,
-    private structs: Map<number, AstStructDecl>,
-    private messages: Map<number, AstMessageDecl>,
-    private traits: Map<number, AstTrait>,
-    private statements: Map<number, AstStatement>,
+    private constants: Map<AstNode["id"], AstConstantDef>,
+    private contracts: Map<AstNode["id"], AstContract>,
+    private nativeFunctions: Map<AstNode["id"], AstNativeFunctionDecl>,
+    private asmFunctions: Map<AstNode["id"], AstAsmFunctionDef>,
+    private primitives: Map<AstNode["id"], AstPrimitiveTypeDecl>,
+    private structs: Map<AstNode["id"], AstStructDecl>,
+    private messages: Map<AstNode["id"], AstMessageDecl>,
+    private traits: Map<AstNode["id"], AstTrait>,
+    private statements: Map<AstNode["id"], AstStatement>,
   ) {}
 
   /**
-   * Returns top-level program entries in order as they defined.
+   * Returns top-level program entries in order as they defined in each file.
    */
-  getProgramEntries(includeStdlib: boolean = false): AstNode[] {
-    return Array.from(this.programEntries).reduce((acc, id) => {
-      if (!includeStdlib && this.stdlibIds.has(id)) {
+  public getProgramEntries(includeStdlib: boolean = false): AstNode[] {
+    return Array.from(this.programEntries.values()).flatMap((idSet) =>
+      Array.from(idSet).reduce((acc, id) => {
+        if (!includeStdlib && this.stdlibIds.has(id)) {
+          return acc;
+        }
+        if (this.functions.has(id)) {
+          acc.push(this.functions.get(id)!);
+        } else if (this.constants.has(id)) {
+          acc.push(this.constants.get(id)!);
+        } else if (this.contracts.has(id)) {
+          acc.push(this.contracts.get(id)!);
+        } else if (this.nativeFunctions.has(id)) {
+          acc.push(this.nativeFunctions.get(id)!);
+        } else if (this.asmFunctions.has(id)) {
+          acc.push(this.asmFunctions.get(id)!);
+        } else if (this.primitives.has(id)) {
+          acc.push(this.primitives.get(id)!);
+        } else if (this.structs.has(id)) {
+          acc.push(this.structs.get(id)!);
+        } else if (this.messages.has(id)) {
+          acc.push(this.messages.get(id)!);
+        } else if (this.traits.has(id)) {
+          acc.push(this.traits.get(id)!);
+        } else {
+          throw InternalException.make(`No entry found for ID: ${id}`);
+        }
         return acc;
-      }
-      if (this.functions.has(id)) {
-        acc.push(this.functions.get(id)!);
-      } else if (this.constants.has(id)) {
-        acc.push(this.constants.get(id)!);
-      } else if (this.contracts.has(id)) {
-        acc.push(this.contracts.get(id)!);
-      } else if (this.nativeFunctions.has(id)) {
-        acc.push(this.nativeFunctions.get(id)!);
-      } else if (this.asmFunctions.has(id)) {
-        acc.push(this.asmFunctions.get(id)!);
-      } else if (this.primitives.has(id)) {
-        acc.push(this.primitives.get(id)!);
-      } else if (this.structs.has(id)) {
-        acc.push(this.structs.get(id)!);
-      } else if (this.messages.has(id)) {
-        acc.push(this.messages.get(id)!);
-      } else if (this.traits.has(id)) {
-        acc.push(this.traits.get(id)!);
-      } else {
-        throw InternalException.make(`No entry found for ID: ${id}`);
-      }
-      return acc;
-    }, [] as AstNode[]);
+      }, [] as AstNode[]),
+    );
   }
   /**
    * Returns all the items defined within the program.
@@ -106,8 +111,8 @@ export class TactASTStore {
    * - filename: Filters out nodes defined in the given file.
    * @returns An iterator for the items.
    */
-  private getItems<T extends { id: number; loc: SrcInfo }>(
-    items: Map<number, T>,
+  public getItems<T extends { id: AstNode["id"]; loc: SrcInfo }>(
+    items: Map<AstNode["id"], T>,
     { includeStdlib = false, filename }: AstItemParams = {},
   ): IterableIterator<T> {
     const filteredStdout = includeStdlib
@@ -124,10 +129,8 @@ export class TactASTStore {
 
   /**
    * Returns all the functions and methods defined within the program.
-   * @param params Additional parameters:
-   * - includeStdlib: If true, includes functions defined in stdlib.
    */
-  getFunctions(
+  public getFunctions(
     params: AstItemParams = {},
   ): IterableIterator<AstFunctionDef | AstReceiver | AstContractInit> {
     return this.getItems(this.functions, params);
@@ -137,10 +140,9 @@ export class TactASTStore {
    * Returns all the constants defined within the program, including top-level constants
    * and contract constants.
    * @param params Additional parameters:
-   * - includeStdlib: If true, includes constants defined in stdlib.
    * - includeContract: If true, includes constants defined within a contract.
    */
-  getConstants(
+  public getConstants(
     params: AstItemParams & { includeContract?: boolean } = {},
   ): IterableIterator<AstConstantDef> {
     const { includeContract = false, ...restParams } = params;
@@ -153,44 +155,50 @@ export class TactASTStore {
         );
   }
 
-  getContracts(params: AstItemParams = {}): IterableIterator<AstContract> {
+  public getContracts(
+    params: AstItemParams = {},
+  ): IterableIterator<AstContract> {
     return this.getItems(this.contracts, params);
   }
 
-  getNativeFunctions(
+  public getNativeFunctions(
     params: AstItemParams = {},
   ): IterableIterator<AstNativeFunctionDecl> {
     return this.getItems(this.nativeFunctions, params);
   }
 
-  getAsmFunctions(
+  public getAsmFunctions(
     params: AstItemParams = {},
   ): IterableIterator<AstAsmFunctionDef> {
     return this.getItems(this.asmFunctions, params);
   }
 
-  getPrimitives(
+  public getPrimitives(
     params: AstItemParams = {},
   ): IterableIterator<AstPrimitiveTypeDecl> {
     return this.getItems(this.primitives, params);
   }
 
-  getStructs(params: AstItemParams = {}): IterableIterator<AstStructDecl> {
+  public getStructs(
+    params: AstItemParams = {},
+  ): IterableIterator<AstStructDecl> {
     return this.getItems(this.structs, params);
   }
 
-  getMessages(params: AstItemParams = {}): IterableIterator<AstMessageDecl> {
+  public getMessages(
+    params: AstItemParams = {},
+  ): IterableIterator<AstMessageDecl> {
     return this.getItems(this.messages, params);
   }
 
-  getTraits(params: AstItemParams = {}): IterableIterator<AstTrait> {
+  public getTraits(params: AstItemParams = {}): IterableIterator<AstTrait> {
     return this.getItems(this.traits, params);
   }
 
   /**
    * Returns all the statements defined within the program.
    */
-  getStatements(): IterableIterator<AstStatement> {
+  public getStatements(): IterableIterator<AstStatement> {
     return this.statements.values();
   }
 
@@ -200,12 +208,12 @@ export class TactASTStore {
    * @returns The function or method if found, otherwise undefined.
    */
   public getFunction(
-    id: number,
+    id: AstNode["id"],
   ): AstFunctionDef | AstReceiver | AstContractInit | undefined {
     return this.functions.get(id);
   }
 
-  public hasFunction(id: number): boolean {
+  public hasFunction(id: AstNode["id"]): boolean {
     return this.getFunction(id) !== undefined;
   }
 
@@ -214,11 +222,11 @@ export class TactASTStore {
    * @param id The unique identifier of the constant.
    * @returns The constant if found, otherwise undefined.
    */
-  public getConstant(id: number): AstConstantDef | undefined {
+  public getConstant(id: AstNode["id"]): AstConstantDef | undefined {
     return this.constants.get(id);
   }
 
-  public hasConstant(id: number): boolean {
+  public hasConstant(id: AstNode["id"]): boolean {
     return this.getConstant(id) !== undefined;
   }
 
@@ -227,11 +235,11 @@ export class TactASTStore {
    * @param id The unique identifier of the contract.
    * @returns The contract if found, otherwise undefined.
    */
-  public getContract(id: number): AstContract | undefined {
+  public getContract(id: AstNode["id"]): AstContract | undefined {
     return this.contracts.get(id);
   }
 
-  public hasContract(id: number): boolean {
+  public hasContract(id: AstNode["id"]): boolean {
     return this.getContract(id) !== undefined;
   }
 
@@ -240,11 +248,13 @@ export class TactASTStore {
    * @param id The unique identifier of the native function.
    * @returns The native function if found, otherwise undefined.
    */
-  public getNativeFunction(id: number): AstNativeFunctionDecl | undefined {
+  public getNativeFunction(
+    id: AstNode["id"],
+  ): AstNativeFunctionDecl | undefined {
     return this.nativeFunctions.get(id);
   }
 
-  public hasNativeFunction(id: number): boolean {
+  public hasNativeFunction(id: AstNode["id"]): boolean {
     return this.getNativeFunction(id) !== undefined;
   }
 
@@ -253,11 +263,11 @@ export class TactASTStore {
    * @param id The unique identifier of the asm function.
    * @returns The asm function if found, otherwise undefined.
    */
-  public getAsmFunction(id: number): AstAsmFunctionDef | undefined {
+  public getAsmFunction(id: AstNode["id"]): AstAsmFunctionDef | undefined {
     return this.asmFunctions.get(id);
   }
 
-  public hasAsmFunction(id: number): boolean {
+  public hasAsmFunction(id: AstNode["id"]): boolean {
     return this.getAsmFunction(id) !== undefined;
   }
 
@@ -266,11 +276,11 @@ export class TactASTStore {
    * @param id The unique identifier of the primitive type.
    * @returns The primitive type if found, otherwise undefined.
    */
-  public getPrimitive(id: number): AstPrimitiveTypeDecl | undefined {
+  public getPrimitive(id: AstNode["id"]): AstPrimitiveTypeDecl | undefined {
     return this.primitives.get(id);
   }
 
-  public hasPrimitive(id: number): boolean {
+  public hasPrimitive(id: AstNode["id"]): boolean {
     return this.getPrimitive(id) !== undefined;
   }
 
@@ -279,11 +289,11 @@ export class TactASTStore {
    * @param id The unique identifier of the struct.
    * @returns The struct if found, otherwise undefined.
    */
-  public getStruct(id: number): AstStructDecl | undefined {
+  public getStruct(id: AstNode["id"]): AstStructDecl | undefined {
     return this.structs.get(id);
   }
 
-  public hasStruct(id: number): boolean {
+  public hasStruct(id: AstNode["id"]): boolean {
     return this.getStruct(id) !== undefined;
   }
 
@@ -292,11 +302,11 @@ export class TactASTStore {
    * @param id The unique identifier of the message.
    * @returns The message if found, otherwise undefined.
    */
-  public getMessage(id: number): AstMessageDecl | undefined {
+  public getMessage(id: AstNode["id"]): AstMessageDecl | undefined {
     return this.messages.get(id);
   }
 
-  public hasMessage(id: number): boolean {
+  public hasMessage(id: AstNode["id"]): boolean {
     return this.getMessage(id) !== undefined;
   }
 
@@ -305,11 +315,11 @@ export class TactASTStore {
    * @param id The unique identifier of the trait.
    * @returns The trait if found, otherwise undefined.
    */
-  public getTrait(id: number): AstTrait | undefined {
+  public getTrait(id: AstNode["id"]): AstTrait | undefined {
     return this.traits.get(id);
   }
 
-  public hasTrait(id: number): boolean {
+  public hasTrait(id: AstNode["id"]): boolean {
     return this.getTrait(id) !== undefined;
   }
 
@@ -322,11 +332,11 @@ export class TactASTStore {
    * @param id The unique identifier of the statement.
    * @returns The statement if found, otherwise undefined.
    */
-  public getStatement(id: number): AstStatement | undefined {
+  public getStatement(id: AstNode["id"]): AstStatement | undefined {
     return this.statements.get(id);
   }
 
-  public hasStatement(id: number): boolean {
+  public hasStatement(id: AstNode["id"]): boolean {
     return this.getStatement(id) !== undefined;
   }
 
@@ -335,21 +345,24 @@ export class TactASTStore {
    * @param contractId The ID of the contract.
    * @returns An array of method IDs or undefined if no contract is found.
    */
-  public getMethods(contractId: number): number[] | undefined {
+  public getMethods(contractId: AstNode["id"]): AstNode["id"][] | undefined {
     const contract = this.getContract(contractId);
     if (!contract) {
       return undefined;
     }
-    return contract.declarations.reduce((result, decl) => {
-      if (
-        decl.kind === "function_def" ||
-        decl.kind === "contract_init" ||
-        decl.kind === "receiver"
-      ) {
-        result.push(decl.id);
-      }
-      return result;
-    }, [] as number[]);
+    return contract.declarations.reduce(
+      (result, decl) => {
+        if (
+          decl.kind === "function_def" ||
+          decl.kind === "contract_init" ||
+          decl.kind === "receiver"
+        ) {
+          result.push(decl.id);
+        }
+        return result;
+      },
+      [] as AstNode["id"][],
+    );
   }
 
   /**
@@ -357,7 +370,7 @@ export class TactASTStore {
    * @param contractId The ID of the contract.
    * @returns The ID of the init function or undefined if the contract does not exist.
    */
-  public getInitId(contractId: number): number | undefined {
+  public getInitId(contractId: AstNode["id"]): AstNode["id"] | undefined {
     const contract = this.getContract(contractId);
     if (!contract) {
       return undefined;
@@ -373,17 +386,22 @@ export class TactASTStore {
    * @param contractId The ID of the contract.
    * @returns An array of constant IDs or undefined if no contract is found.
    */
-  public getContractConstants(contractId: number): number[] | undefined {
+  public getContractConstants(
+    contractId: AstNode["id"],
+  ): AstNode["id"][] | undefined {
     const contract = this.getContract(contractId);
     if (!contract) {
       return undefined;
     }
-    return contract.declarations.reduce((result, decl) => {
-      if (decl.kind === "constant_def") {
-        result.push(decl.id);
-      }
-      return result;
-    }, [] as number[]);
+    return contract.declarations.reduce(
+      (result, decl) => {
+        if (decl.kind === "constant_def") {
+          result.push(decl.id);
+        }
+        return result;
+      },
+      [] as AstNode["id"][],
+    );
   }
 
   /**
@@ -391,7 +409,9 @@ export class TactASTStore {
    * @param contractId The ID of the contract.
    * @returns An array of AstFieldDecl or undefined if no contract is found.
    */
-  public getContractFields(contractId: number): AstFieldDecl[] | undefined {
+  public getContractFields(
+    contractId: AstNode["id"],
+  ): AstFieldDecl[] | undefined {
     const contract = this.getContract(contractId);
     if (!contract) {
       return undefined;
@@ -409,7 +429,9 @@ export class TactASTStore {
    * @param contractId The ID of the contract.
    * @returns An array of AstFieldDecl or undefined if no contract or one its trait are found.
    */
-  public getInheritedFields(contractId: number): AstFieldDecl[] | undefined {
+  public getInheritedFields(
+    contractId: AstNode["id"],
+  ): AstFieldDecl[] | undefined {
     const contract = this.getContract(contractId);
     if (!contract) {
       return undefined;
@@ -429,10 +451,67 @@ export class TactASTStore {
     return fields;
   }
 
-  private fileMatches = (node: { loc: SrcInfo }, filename: string): boolean =>
+  /**
+   * Retrieves items of specified kinds defined within a given file.
+   * @param kinds An array of kinds to filter the items.
+   * @param params Additional parameters:
+   * - includeStdlib: If true, includes items defined in stdlib.
+   * - filename: The filename to filter items by (required).
+   * @returns An array of matching AstNode items.
+   */
+  public getItemsByKinds(
+    kinds: AstNode["kind"][],
+    params: AstItemParams & { filename: string },
+  ): Exclude<AstNode, AstModule>[] {
+    const result: Exclude<AstNode, AstModule>[] = [];
+    // TODO: Should be rewritten: https://github.com/nowarp/misti/issues/186
+    for (const kind of kinds) {
+      switch (kind) {
+        case "function_def":
+        case "receiver":
+        case "contract_init":
+          result.push(...Array.from(this.getFunctions(params)));
+          break;
+        case "constant_def":
+        case "constant_decl":
+          result.push(
+            ...Array.from(
+              this.getConstants({ ...params, includeContract: true }),
+            ),
+          );
+          break;
+        case "contract":
+          result.push(...Array.from(this.getContracts(params)));
+          break;
+        case "native_function_decl":
+          result.push(...Array.from(this.getNativeFunctions(params)));
+          break;
+        case "asm_function_def":
+          result.push(...Array.from(this.getAsmFunctions(params)));
+          break;
+        case "primitive_type_decl":
+          result.push(...Array.from(this.getPrimitives(params)));
+          break;
+        case "struct_decl":
+          result.push(...Array.from(this.getStructs(params)));
+          break;
+        case "message_decl":
+          result.push(...Array.from(this.getMessages(params)));
+          break;
+        case "trait":
+          result.push(...Array.from(this.getTraits(params)));
+          break;
+      }
+    }
+    return params.filename
+      ? result.filter((item) => item.loc.file === params.filename)
+      : result;
+  }
+
+  public fileMatches = (node: { loc: SrcInfo }, filename: string): boolean =>
     node.loc.file !== null && node.loc.file === filename;
 
-  private *filterIterator<T>(
+  public *filterIterator<T>(
     iterator: IterableIterator<T>,
     condition: (item: T) => boolean,
   ): IterableIterator<T> {

--- a/src/internals/ir/builders/astStore.ts
+++ b/src/internals/ir/builders/astStore.ts
@@ -24,7 +24,7 @@ import { AstStore } from "@tact-lang/compiler/dist/grammar/store";
  * Transforms AstStore to TactASTStore.
  */
 export class TactASTStoreBuilder {
-  private programEntries = new Set<number>();
+  private programEntries: Map<string, Set<number>> = new Map();
   private stdlibIds = new Set<number>();
   private contractConstants = new Set<number>();
   private functions = new Map<
@@ -58,7 +58,14 @@ export class TactASTStoreBuilder {
     processor: (element: T) => void,
   ): void {
     elements.forEach((element) => {
-      this.programEntries.add(element.id);
+      const filename = element.loc.file;
+      if (filename === null) return;
+      const elements = this.programEntries.get(filename);
+      if (elements) {
+        elements.add(element.id);
+      } else {
+        this.programEntries.set(filename, new Set([element.id]));
+      }
       if (definedInStdlib(this.ctx, element.loc)) {
         this.stdlibIds.add(element.id);
       }

--- a/src/internals/ir/cfg.ts
+++ b/src/internals/ir/cfg.ts
@@ -9,8 +9,7 @@ import { IdxGenerator } from "./indices";
 import { BasicBlockIdx, CFGIdx, EdgeIdx, FunctionName } from "./types";
 import { InternalException } from "../exceptions";
 import { AstStatement, SrcInfo } from "@tact-lang/compiler/dist/grammar/ast";
-
-export type EntryOrigin = "user" | "stdlib";
+import { ItemOrigin } from "@tact-lang/compiler/dist/grammar/grammar";
 
 /**
  * Represents an edge in a Control Flow Graph (CFG), connecting two basic blocks.
@@ -117,7 +116,7 @@ export class CFG {
     public name: FunctionName,
     public id: number,
     public kind: FunctionKind,
-    public origin: EntryOrigin,
+    public origin: ItemOrigin,
     public nodes: BasicBlock[],
     public edges: Edge[],
     public ref: SrcInfo,

--- a/src/internals/ir/imports.ts
+++ b/src/internals/ir/imports.ts
@@ -4,8 +4,8 @@ import { ItemOrigin } from "@tact-lang/compiler/dist/grammar/grammar";
 
 export type ImportNodeIdx = number;
 export type ImportEdgeIdx = number;
-
 export type ImportLanguage = "tact" | "func";
+export type ImportDirection = "forward" | "backward";
 
 /**
  * Represents a node in the import graph, corresponding to a file.
@@ -75,10 +75,32 @@ export class ImportGraph {
   }
 
   /**
-   * Finds independent subgraphs of files not connected by `import` directives.
+   * Iterates over all nodes in the graph and calls the provided callback for each nodes.
+   * @param callback A function to be called for each nodes in the graph.
    */
-  public getDisconnectedComponents(): ImportNode[][] {
-    throw new Error("Not yet implemented");
+  public forEachNode(callback: (node: ImportNode) => void): void {
+    this.nodes.forEach(callback);
+  }
+
+  /**
+   * Iterates over all edges in the graph and calls the provided callback for each edge.
+   * @param callback A function to be called for each edge in the graph.
+   */
+  public forEachEdge(callback: (edge: ImportEdge) => void): void {
+    this.edges.forEach(callback);
+  }
+
+  /**
+   * Returns true if `parent` imports `child`, directly or indirectly.
+   */
+  public imports(parent: ImportNodeIdx, child: ImportNodeIdx): boolean {
+    let found = false;
+    this.bfs(parent, (node, _) => {
+      if (node.idx === child) {
+        found = true;
+      }
+    });
+    return found;
   }
 
   /**
@@ -86,6 +108,101 @@ export class ImportGraph {
    * These nodes could be entry points of the project.
    */
   public getContractNodes(): ImportNode[] {
-    throw new Error("Not yet implemented");
+    return Array.from(this.nodes.values()).filter((node) => node.hasContract);
+  }
+
+  /**
+   * Performs a BFS on the import graph.
+   * @param start The starting node index for the BFS.
+   * @param callback A function called for each visited node and the edge through which it was reached.
+   */
+  public bfs(
+    start: ImportNodeIdx,
+    callback: (node: ImportNode, edge: ImportEdge | null) => void,
+    { direction = "forward" }: Partial<{ direction: ImportDirection }> = {},
+  ): void {
+    const queue: [ImportNodeIdx, ImportEdge | null][] = [[start, null]];
+    const visited = new Set<ImportNodeIdx>();
+    while (queue.length > 0) {
+      const [currentIdx, incomingEdge] = queue.shift()!;
+      if (visited.has(currentIdx)) continue;
+      const currentNode = this.nodes[this.nodesMap.get(currentIdx)!];
+      visited.add(currentIdx);
+      callback(currentNode, incomingEdge);
+      const edges =
+        direction === "backward" ? currentNode.inEdges : currentNode.outEdges;
+      edges.forEach((edgeIdx) => {
+        const edge = this.edges[this.edgesMap.get(edgeIdx)!];
+        const nextNodeIdx = direction === "backward" ? edge.src : edge.dst;
+        if (!visited.has(nextNodeIdx)) {
+          queue.push([nextNodeIdx, edge]);
+        }
+      });
+    }
+  }
+
+  /**
+   * Finds a node in the graph by its import path.
+   * @param importPath The absolute path of the file to find.
+   * @returns The ImportNode if found, or undefined if not found.
+   */
+  public findNodeByPath(importPath: string): ImportNode | undefined {
+    return this.nodes.find((node) => node.importPath === importPath);
+  }
+
+  /**
+   * Generic method to get all connections in a specified direction.
+   * @param nodeIdx The index of the node to start from.
+   * @param direction The direction of traversal ('forward' or 'backward').
+   * @returns An array of ImportNodes connected to the given node in the specified direction.
+   */
+  private getConnectionsInDirection(
+    nodeIdx: ImportNodeIdx,
+    direction: ImportDirection,
+  ): ImportNode[] {
+    const result: ImportNode[] = [];
+    this.bfs(
+      nodeIdx,
+      (node, edge) => {
+        // Skip the starting node
+        if (edge !== null) result.push(node);
+      },
+      { direction },
+    );
+    return result;
+  }
+
+  /**
+   * Returns all direct and indirect import connections for the given node index.
+   * @param nodeIdx The index of the node to start from.
+   * @returns An array of ImportNodes that are directly or indirectly imported by the given node.
+   */
+  public getAllImportConnections(nodeIdx: ImportNodeIdx): ImportNode[] {
+    return this.getConnectionsInDirection(nodeIdx, "forward");
+  }
+
+  /**
+   * Returns all nodes that directly or indirectly import the given node.
+   * @param nodeIdx The index of the node to start from.
+   * @returns An array of ImportNodes that directly or indirectly import the given node.
+   */
+  public getAllImportingNodes(nodeIdx: ImportNodeIdx): ImportNode[] {
+    return this.getConnectionsInDirection(nodeIdx, "backward");
+  }
+
+  /**
+   * Finds a direct connection (edge) between two nodes.
+   * @param sourceIdx The index of the source node.
+   * @param targetIdx The index of the target node.
+   * @returns The ImportEdge if a direct connection exists, or undefined if not found.
+   */
+  public findConnection(
+    sourceIdx: ImportNodeIdx,
+    targetIdx: ImportNodeIdx,
+  ): ImportEdge | undefined {
+    const sourceNode = this.nodes[this.nodesMap.get(sourceIdx)!];
+    return Array.from(sourceNode.outEdges)
+      .map((edgeIdx) => this.edges[this.edgesMap.get(edgeIdx)!])
+      .find((edge) => edge.dst === targetIdx);
   }
 }

--- a/src/internals/ir/index.ts
+++ b/src/internals/ir/index.ts
@@ -1,13 +1,4 @@
-export {
-  Edge,
-  BasicBlockKind,
-  BasicBlock,
-  FunctionKind,
-  CFG,
-  getPredecessors,
-  getSuccessors,
-  EntryOrigin,
-} from "./cfg";
+export * from "./cfg";
 export { TactASTStore } from "./astStore";
 export * from "./imports";
 export { CompilationUnit, Contract } from "./ir";

--- a/src/internals/ir/index.ts
+++ b/src/internals/ir/index.ts
@@ -1,5 +1,5 @@
 export * from "./cfg";
-export { TactASTStore } from "./astStore";
+export * from "./astStore";
 export * from "./imports";
 export { CompilationUnit, Contract } from "./ir";
 export * from "./types";

--- a/src/tools/dumpAst.ts
+++ b/src/tools/dumpAst.ts
@@ -31,7 +31,7 @@ export class DumpAst extends Tool<DumpAstOptions> {
 
   private dumpJSON(cu: CompilationUnit): string {
     return JSONbig.stringify(
-      cu.ast.getProgramEntries(this.options.dumpStdlib),
+      cu.ast.getProgramEntries({ includeStdlib: this.options.dumpStdlib }),
       null,
       2,
     );

--- a/test/importGraph.spec.ts
+++ b/test/importGraph.spec.ts
@@ -1,0 +1,121 @@
+import {
+  ImportGraph,
+  ImportNode,
+  ImportEdge,
+} from "../src/internals/ir/imports";
+import { SrcInfo } from "@tact-lang/compiler/dist/grammar/ast";
+import { ItemOrigin } from "@tact-lang/compiler/dist/grammar/grammar";
+
+describe("ImportGraph", () => {
+  let node1: ImportNode;
+  let node2: ImportNode;
+  let node3: ImportNode;
+  let edge1: ImportEdge;
+  let edge2: ImportEdge;
+  let graph: ImportGraph;
+
+  beforeEach(() => {
+    node1 = new ImportNode(
+      "Node1",
+      {} as ItemOrigin,
+      "/path/to/node1",
+      "tact",
+      true,
+    );
+    node1.idx = 1;
+    node2 = new ImportNode(
+      "Node2",
+      {} as ItemOrigin,
+      "/path/to/node2",
+      "tact",
+      false,
+    );
+    node2.idx = 2;
+    node3 = new ImportNode(
+      "Node3",
+      {} as ItemOrigin,
+      "/path/to/node3",
+      "func",
+      true,
+    );
+    node3.idx = 3;
+
+    // Create edges from node1 to node2 and node2 to node3
+    edge1 = new ImportEdge(node1.idx, node2.idx, {} as SrcInfo);
+    edge1.idx = 1;
+    edge2 = new ImportEdge(node2.idx, node3.idx, {} as SrcInfo);
+    edge2.idx = 2;
+
+    // Update node inEdges and outEdges
+    node1.outEdges.add(edge1.idx);
+    node2.inEdges.add(edge1.idx);
+    node2.outEdges.add(edge2.idx);
+    node3.inEdges.add(edge2.idx);
+
+    graph = new ImportGraph([node1, node2, node3], [edge1, edge2]);
+  });
+
+  test("forEachNode should iterate over all nodes", () => {
+    const nodeNames: string[] = [];
+    graph.forEachNode((node) => {
+      nodeNames.push(node.name);
+    });
+    expect(nodeNames).toContain("Node1");
+    expect(nodeNames).toContain("Node2");
+    expect(nodeNames).toContain("Node3");
+  });
+
+  test("forEachEdge should iterate over all edges", () => {
+    const edgeIdxs: number[] = [];
+    graph.forEachEdge((edge) => {
+      edgeIdxs.push(edge.idx);
+    });
+    expect(edgeIdxs).toContain(edge1.idx);
+    expect(edgeIdxs).toContain(edge2.idx);
+  });
+
+  test("imports should return true if node imports another node", () => {
+    expect(graph.imports(node1.idx, node2.idx)).toBe(true);
+    expect(graph.imports(node1.idx, node3.idx)).toBe(true);
+    expect(graph.imports(node2.idx, node3.idx)).toBe(true);
+    expect(graph.imports(node2.idx, node1.idx)).toBe(false);
+  });
+
+  test("getContractNodes should return nodes with hasContract = true", () => {
+    const contractNodes = graph.getContractNodes();
+    const contractNodeNames = contractNodes.map((node) => node.name);
+    expect(contractNodeNames).toContain("Node1");
+    expect(contractNodeNames).toContain("Node3");
+    expect(contractNodeNames).not.toContain("Node2");
+  });
+
+  test("findNodeByPath should return correct node", () => {
+    const node = graph.findNodeByPath("/path/to/node2");
+    expect(node).toBeDefined();
+    expect(node!.name).toBe("Node2");
+  });
+
+  test("getAllImportConnections should return all nodes imported by a node", () => {
+    const connections = graph.getAllImportConnections(node1.idx);
+    const connectionNames = connections.map((node) => node.name);
+    expect(connectionNames).toContain("Node2");
+    expect(connectionNames).toContain("Node3");
+    expect(connectionNames).not.toContain("Node1");
+  });
+
+  test("getAllImportingNodes should return all nodes that import a node", () => {
+    const importingNodes = graph.getAllImportingNodes(node3.idx);
+    const importingNodeNames = importingNodes.map((node) => node.name);
+    expect(importingNodeNames).toContain("Node1");
+    expect(importingNodeNames).toContain("Node2");
+    expect(importingNodeNames).not.toContain("Node3");
+  });
+
+  test("findConnection should return the edge between two nodes if it exists", () => {
+    const edge = graph.findConnection(node1.idx, node2.idx);
+    expect(edge).toBeDefined();
+    expect(edge!.idx).toBe(edge1.idx);
+    const noEdge = graph.findConnection(node1.idx, node3.idx);
+    expect(noEdge).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Initially, it was a part of #111, but it seems it makes not sense to implement it at the moment, since we'll need some representation of UD-chains for it.

- [ ] ~~I have updated `CHANGELOG.md`~~
- [x] I have added tests to demonstrate the contribution is correctly implemented
- [x] No test failures were reported when running `yarn test-all`
- [ ] I did not do unrelated and/or undiscussed refactorings

