### PR TITLE
New Detector: `UnusedExpressionResult`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SendInLoop` detector: PR [#168](https://github.com/nowarp/misti/pulls/168)
 - `CellOverflow` detector: PR [#177](https://github.com/nowarp/misti/pulls/177)
 - `UnboundMap` detector: Issue [#50](https://github.com/nowarp/misti/issues/50)
+- `UnusedExpressionResult` detector: PR [#190](https://github.com/nowarp/misti/pulls/190)
 - Import Graph: PR [#180](https://github.com/nowarp/misti/pulls/180)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Misti is a static analysis tool designed for smart contracts on the [TON blockchain](https://ton.org/).
 
 ### Language Support
-- [Tact](https://tact-lang.org/): 23 detectors [are available](https://nowarp.io/tools/misti/docs/next/detectors)
+- [Tact](https://tact-lang.org/): 24 detectors [are available](https://nowarp.io/tools/misti/docs/next/detectors)
 - [FunC](https://docs.ton.org/develop/func/overview) support is [planned](https://github.com/nowarp/misti/issues/56) by the end of the year
 
 ### Use Cases

--- a/src/detectors/builtin/unusedExpressionResult.ts
+++ b/src/detectors/builtin/unusedExpressionResult.ts
@@ -129,11 +129,14 @@ export class UnusedExpressionResult extends ASTDetector {
         break;
       case "static_call": {
         const funName = idText(expr.function);
-        if (!IGNORED_FUNCTIONS.has(funName) && this.freeFunctionReturnTypes.get(funName)) {
+        if (
+          !IGNORED_FUNCTIONS.has(funName) &&
+          this.freeFunctionReturnTypes.get(funName)
+        ) {
           warnings.push(warn());
         }
         break;
-        }
+      }
       case "conditional":
         warnings.push(
           ...this.checkExpression(expr.thenBranch, methodReturnTypes),

--- a/src/detectors/builtin/unusedExpressionResult.ts
+++ b/src/detectors/builtin/unusedExpressionResult.ts
@@ -13,6 +13,11 @@ import {
 import { prettyPrint } from "@tact-lang/compiler/dist/prettyPrinter";
 
 /**
+ * Suppressed functions which result typically could be ignored.
+ */
+const IGNORED_FUNCTIONS = new Set<string>(["send"]);
+
+/**
  * A detector that identifies expression statements whose result is unused.
  *
  * ## Why is it bad?
@@ -122,11 +127,13 @@ export class UnusedExpressionResult extends ASTDetector {
           warnings.push(warn());
         }
         break;
-      case "static_call":
-        if (this.freeFunctionReturnTypes.get(idText(expr.function))) {
+      case "static_call": {
+        const funName = idText(expr.function);
+        if (!IGNORED_FUNCTIONS.has(funName) && this.freeFunctionReturnTypes.get(funName)) {
           warnings.push(warn());
         }
         break;
+        }
       case "conditional":
         warnings.push(
           ...this.checkExpression(expr.thenBranch, methodReturnTypes),

--- a/src/detectors/builtin/unusedExpressionResult.ts
+++ b/src/detectors/builtin/unusedExpressionResult.ts
@@ -1,0 +1,143 @@
+import { CompilationUnit } from "../../internals/ir";
+import { forEachStatement, isSelf } from "../../internals/tact";
+import { unreachable } from "../../internals/util";
+import { MistiTactWarning, Severity } from "../../internals/warnings";
+import { ASTDetector } from "../detector";
+import {
+  AstExpression,
+  AstStatementExpression,
+  AstNode,
+  AstType,
+  idText,
+} from "@tact-lang/compiler/dist/grammar/ast";
+import { prettyPrint } from "@tact-lang/compiler/dist/prettyPrinter";
+
+/**
+ * A detector that identifies expression statements whose result is unused.
+ *
+ * ## Why is it bad?
+ * Expression statements that don't alter the contract's state and whose results are not used
+ * can lead to inefficiency, dead code, and potential confusion. They add unnecessary complexity
+ * without contributing to the logic or state of the contract.
+ *
+ * ## Example
+ * ```tact
+ * self.foo == 3; // Warning: unused boolean expression
+ * inc(a); // Warning: unused return value
+ * ```
+ *
+ * Use instead:
+ * ```tact
+ * self.foo = 3; // Fixed: corrected assignment
+ * newValue = inc(a); // OK: result is now used
+ * let _ = inc(a); // OK: explicitly ignored
+ * ```
+ */
+export class UnusedExpressionResult extends ASTDetector {
+  severity = Severity.MEDIUM;
+
+  /**
+   * Return types that the available free functions have.
+   */
+  private freeFunctionReturnTypes = new Map<string, AstType | null>();
+
+  async check(cu: CompilationUnit): Promise<MistiTactWarning[]> {
+    this.freeFunctionReturnTypes = cu.ast.getReturnTypes();
+    return cu.ast.getProgramEntries().reduce((acc, node) => {
+      if (node.kind === "trait" || node.kind === "contract") {
+        const methodReturnTypes = cu.ast.getMethodReturnTypes(node.id);
+        acc = acc.concat(this.checkFunction(node, methodReturnTypes));
+      } else if (node.kind === "function_def") {
+        acc = acc.concat(this.checkFunction(node, undefined));
+      }
+      return acc;
+    }, [] as MistiTactWarning[]);
+  }
+
+  /**
+   * @param methodReturnTypes Return types of methods of the current trait/contract.
+   */
+  private checkFunction(
+    node: AstNode,
+    methodReturnTypes: Map<string, AstType | null> | undefined,
+  ): MistiTactWarning[] {
+    const warnings: MistiTactWarning[] = [];
+    forEachStatement(node, (stmt) => {
+      if (stmt.kind === "statement_expression") {
+        this.checkExpressionStatement(stmt, methodReturnTypes).forEach((w) =>
+          warnings.push(w),
+        );
+      }
+    });
+    return warnings;
+  }
+
+  /**
+   * Generates warnings if `stmt` contains expressions which result is unused.
+   * @param methodReturnTypes Return types of methods of the current trait/contract.
+   */
+  private checkExpressionStatement(
+    stmt: AstStatementExpression,
+    methodReturnTypes: Map<string, AstType | null> | undefined,
+  ): MistiTactWarning[] {
+    return this.checkExpression(stmt.expression, methodReturnTypes);
+  }
+
+  /**
+   * @param methodReturnTypes Return types of methods of the current trait/contract.
+   */
+  private checkExpression(
+    expr: AstExpression,
+    methodReturnTypes: Map<string, AstType | null> | undefined,
+  ): MistiTactWarning[] {
+    const warnings: MistiTactWarning[] = [];
+    const warn = () =>
+      this.makeWarning(
+        `Result of evaluation of ${prettyPrint(expr)} is unused`,
+        expr.loc,
+        {
+          suggestion: "Remove the expression or assign its result",
+        },
+      );
+    switch (expr.kind) {
+      case "struct_instance":
+      case "init_of":
+        break; // do nothing
+      case "op_binary":
+      case "op_unary":
+      case "field_access":
+      case "number":
+      case "id":
+      case "boolean":
+      case "null":
+      case "string":
+        warnings.push(warn());
+        break;
+      case "method_call":
+        if (
+          methodReturnTypes &&
+          isSelf(expr.self) &&
+          methodReturnTypes.get(idText(expr.method))
+        ) {
+          warnings.push(warn());
+        }
+        break;
+      case "static_call":
+        if (this.freeFunctionReturnTypes.get(idText(expr.function))) {
+          warnings.push(warn());
+        }
+        break;
+      case "conditional":
+        warnings.push(
+          ...this.checkExpression(expr.thenBranch, methodReturnTypes),
+        );
+        warnings.push(
+          ...this.checkExpression(expr.elseBranch, methodReturnTypes),
+        );
+        break;
+      default:
+        unreachable(expr);
+    }
+    return warnings;
+  }
+}

--- a/src/detectors/detector.ts
+++ b/src/detectors/detector.ts
@@ -371,6 +371,13 @@ export const BuiltInDetectors: Record<string, DetectorEntry> = {
       ),
     enabledByDefault: false,
   },
+  UnusedExpressionResult: {
+    loader: (ctx: MistiContext) =>
+      import("./builtin/unusedExpressionResult").then(
+        (module) => new module.UnusedExpressionResult(ctx),
+      ),
+    enabledByDefault: true,
+  },
 };
 
 /**

--- a/src/internals/ir/astStore.ts
+++ b/src/internals/ir/astStore.ts
@@ -2,7 +2,9 @@ import { InternalException } from "../exceptions";
 import {
   AstAsmFunctionDef,
   AstConstantDef,
+  idText,
   AstModule,
+  AstType,
   AstContract,
   SrcInfo,
   AstContractInit,
@@ -28,6 +30,8 @@ export type AstItemParams = Partial<{
   filename?: string;
 }>;
 
+type FunctionName = string;
+type MethodName = string;
 type Filename = string;
 
 /**
@@ -42,7 +46,7 @@ export class TactASTStore {
    * by their unique AST identifiers.
    *
    * @param stdlibIds Identifiers of AST elements defined in stdlib.
-   * @param contractConstants Identifiers of constants defined within contracts.
+   * @param contractEntries Items defined within contracts and traits.
    * @param programEntries Identifiers of AST elements defined on the top-level of each file.
    * @param functions Functions and methods including user-defined and special methods.
    * @param constants Constants defined across the compilation unit.
@@ -57,7 +61,7 @@ export class TactASTStore {
    */
   constructor(
     private stdlibIds = new Set<AstNode["id"]>(),
-    private contractConstants = new Set<AstNode["id"]>(),
+    private contractEntries = new Map<AstContract["id"], Set<AstNode["id"]>>(),
     private programEntries: Map<Filename, Set<AstNode["id"]>>,
     private functions: Map<
       AstNode["id"],
@@ -168,10 +172,7 @@ export class TactASTStore {
     const constants = this.getItems(this.constants, restParams);
     return includeContract
       ? constants
-      : this.filterIterator(
-          constants,
-          (c) => !this.contractConstants.has(c.id),
-        );
+      : this.filterIterator(constants, (c) => !this.isContractItem(c.id));
   }
 
   public getContracts(
@@ -528,6 +529,55 @@ export class TactASTStore {
       ? result.filter((item) => item.loc.file === params.filename)
       : result;
   }
+
+  /**
+   * Retrieves return types from the callable functions available within CompilationUnit.
+   */
+  public getReturnTypes(): Map<FunctionName, AstType | null> {
+    const result = new Map<FunctionName, AstType | null>();
+    this.asmFunctions.forEach((f) => result.set(idText(f.name), f.return));
+    this.functions.forEach((f) => {
+      if (!this.isContractItem(f.id))
+        result.set(
+          // Other kinds of functions cannot be present on the top-level
+          idText((f as AstFunctionDef).name),
+          (f as AstFunctionDef).return,
+        );
+    });
+    return result;
+  }
+
+  /**
+   * Retrieves return types from the callable methods defined in the given contract/trait.
+   */
+  public getMethodReturnTypes(
+    contractId: AstContract["id"],
+  ): Map<MethodName, AstType | null> {
+    const result = new Map<MethodName, AstType | null>();
+    const contractEntries = this.contractEntries.get(contractId);
+    if (contractEntries) {
+      this.functions.forEach((f) => {
+        // Don't consider receviers/inits since we cannot call them from the contract
+        if (f.kind === "function_def" && contractEntries.has(f.id))
+          result.set(idText(f.name), f.return);
+      });
+    }
+    return result;
+  }
+
+  /**
+   * Returns true iff `itemId` present in any of the contract/trait items.
+   */
+  private isContractItem(itemId: AstNode["id"]): boolean {
+    if (this.isContractItemCache.has(itemId))
+      return this.isContractItemCache.get(itemId)!;
+    const result = [...this.contractEntries.values()].some((set) =>
+      set.has(itemId),
+    );
+    this.isContractItemCache.set(itemId, result);
+    return result;
+  }
+  private isContractItemCache = new Map<AstNode["id"], boolean>();
 
   private fileMatches = (node: { loc: SrcInfo }, filename: string): boolean =>
     node.loc.file !== null && node.loc.file === filename;

--- a/test/detectors/UnusedExpressionResult.expected.out
+++ b/test/detectors/UnusedExpressionResult.expected.out
@@ -1,0 +1,62 @@
+[MEDIUM] UnusedExpressionResult: Result of evaluation of fun2() is unused
+test/detectors/UnusedExpressionResult.tact:5:5:
+  4 |     fun1(); // OK
+> 5 |     fun2(); // Bad
+          ^
+  6 |     1; // Bad
+Help: Remove the expression or assign its result
+See: https://nowarp.io/tools/misti/docs/detectors/UnusedExpressionResult
+
+[MEDIUM] UnusedExpressionResult: Result of evaluation of 1 is unused
+test/detectors/UnusedExpressionResult.tact:6:5:
+  5 |     fun2(); // Bad
+> 6 |     1; // Bad
+          ^
+  7 |     1 == 1; // Bad
+Help: Remove the expression or assign its result
+See: https://nowarp.io/tools/misti/docs/detectors/UnusedExpressionResult
+
+[MEDIUM] UnusedExpressionResult: Result of evaluation of 1 == 1 is unused
+test/detectors/UnusedExpressionResult.tact:7:5:
+  6 |     1; // Bad
+> 7 |     1 == 1; // Bad
+          ^
+  8 | 
+Help: Remove the expression or assign its result
+See: https://nowarp.io/tools/misti/docs/detectors/UnusedExpressionResult
+
+[MEDIUM] UnusedExpressionResult: Result of evaluation of a == 43 is unused
+test/detectors/UnusedExpressionResult.tact:10:5:
+   9 |     let a = 42;
+> 10 |     a == 43; // Bad
+           ^
+  11 | 
+Help: Remove the expression or assign its result
+See: https://nowarp.io/tools/misti/docs/detectors/UnusedExpressionResult
+
+[MEDIUM] UnusedExpressionResult: Result of evaluation of self.method1() is unused
+test/detectors/UnusedExpressionResult.tact:25:9:
+  24 |     fun test() {
+> 25 |         self.method1(); // Bad: Calling method returning Int
+               ^
+  26 |     }
+Help: Remove the expression or assign its result
+See: https://nowarp.io/tools/misti/docs/detectors/UnusedExpressionResult
+
+[MEDIUM] UnusedExpressionResult: Result of evaluation of self.traitMethod1() is unused
+test/detectors/UnusedExpressionResult.tact:37:9:
+  36 |     fun test() {
+> 37 |         self.traitMethod1(); // Bad
+               ^
+  38 |         self.traitMethod2(); // OK
+Help: Remove the expression or assign its result
+See: https://nowarp.io/tools/misti/docs/detectors/UnusedExpressionResult
+
+[MEDIUM] UnusedExpressionResult: Result of evaluation of self.traitMethod3() is unused
+test/detectors/UnusedExpressionResult.tact:39:9:
+  38 |         self.traitMethod2(); // OK
+> 39 |         self.traitMethod3(); // Bad
+               ^
+  40 |     }
+Help: Remove the expression or assign its result
+See: https://nowarp.io/tools/misti/docs/detectors/UnusedExpressionResult

--- a/test/detectors/UnusedExpressionResult.expected.out
+++ b/test/detectors/UnusedExpressionResult.expected.out
@@ -35,28 +35,28 @@ Help: Remove the expression or assign its result
 See: https://nowarp.io/tools/misti/docs/detectors/UnusedExpressionResult
 
 [MEDIUM] UnusedExpressionResult: Result of evaluation of self.method1() is unused
-test/detectors/UnusedExpressionResult.tact:25:9:
-  24 |     fun test() {
-> 25 |         self.method1(); // Bad: Calling method returning Int
+test/detectors/UnusedExpressionResult.tact:27:9:
+  26 |     fun test() {
+> 27 |         self.method1(); // Bad: Calling method returning Int
                ^
-  26 |     }
+  28 |     }
 Help: Remove the expression or assign its result
 See: https://nowarp.io/tools/misti/docs/detectors/UnusedExpressionResult
 
 [MEDIUM] UnusedExpressionResult: Result of evaluation of self.traitMethod1() is unused
-test/detectors/UnusedExpressionResult.tact:37:9:
-  36 |     fun test() {
-> 37 |         self.traitMethod1(); // Bad
+test/detectors/UnusedExpressionResult.tact:39:9:
+  38 |     fun test() {
+> 39 |         self.traitMethod1(); // Bad
                ^
-  38 |         self.traitMethod2(); // OK
+  40 |         self.traitMethod2(); // OK
 Help: Remove the expression or assign its result
 See: https://nowarp.io/tools/misti/docs/detectors/UnusedExpressionResult
 
 [MEDIUM] UnusedExpressionResult: Result of evaluation of self.traitMethod3() is unused
-test/detectors/UnusedExpressionResult.tact:39:9:
-  38 |         self.traitMethod2(); // OK
-> 39 |         self.traitMethod3(); // Bad
+test/detectors/UnusedExpressionResult.tact:41:9:
+  40 |         self.traitMethod2(); // OK
+> 41 |         self.traitMethod3(); // Bad
                ^
-  40 |     }
+  42 |     }
 Help: Remove the expression or assign its result
 See: https://nowarp.io/tools/misti/docs/detectors/UnusedExpressionResult

--- a/test/detectors/UnusedExpressionResult.tact
+++ b/test/detectors/UnusedExpressionResult.tact
@@ -10,6 +10,8 @@ fun test() {
     a == 43; // Bad
 
     require(1 == 1, "1"); // OK: This function is not defined in AST
+
+    send(SendParameters{ to: sender(), value: 42 }); // OK: Ignored function
 }
 
 // Check contract methods

--- a/test/detectors/UnusedExpressionResult.tact
+++ b/test/detectors/UnusedExpressionResult.tact
@@ -1,0 +1,41 @@
+fun fun1() {}
+fun fun2(): Int { return 42; }
+fun test() {
+    fun1(); // OK
+    fun2(); // Bad
+    1; // Bad
+    1 == 1; // Bad
+
+    let a = 42;
+    a == 43; // Bad
+
+    require(1 == 1, "1"); // OK: This function is not defined in AST
+}
+
+// Check contract methods
+contract C1 {
+    fun method1() {} // to check method name collision with C2.method1
+    fun test() {
+        self.method1(); // OK: Calling method returning void
+    }
+}
+contract C2 {
+    fun method1(): Int { return 42; }
+    fun test() {
+        self.method1(); // Bad: Calling method returning Int
+    }
+}
+
+// Check methods defined in parent traits
+trait T1 {
+    fun traitMethod1(): Int { return 42; }
+    fun traitMethod2() {}
+}
+trait T2 with T1 { fun traitMethod3(): Int { return 42; } }
+contract CT with T2 {
+    fun test() {
+        self.traitMethod1(); // Bad
+        self.traitMethod2(); // OK
+        self.traitMethod3(); // Bad
+    }
+}


### PR DESCRIPTION
Closes #83

- [x] I have updated `CHANGELOG.md`
- [x] I have added tests to demonstrate the contribution is correctly implemented
- [x] No test failures were reported when running `yarn test-all`
- [x] I did not do unrelated and/or undiscussed refactorings

