### PR TITLE
Dynamic suggestions for integer literals in `SuspiciousMessageMode` detector

### DIFF
--- a/src/detectors/builtin/suspiciousMessageMode.ts
+++ b/src/detectors/builtin/suspiciousMessageMode.ts
@@ -107,13 +107,18 @@ export class SuspiciousMessageMode extends ASTDetector {
           flagsUsed.add(flagName);
           break;
         case "number":
+          let suggestion: string = `Replace integer literal \`${e.value}\` with symbolic flag constants`;
+          if (e.value === 64n) {
+            suggestion = "Replace `64` with `SendRemainingValue`";
+          } else if (e.value === 128n) {
+            suggestion = "Replace `128` with `SendRemainingBalance`";
+          }
           warnings.push(
             this.makeWarning(
-              "Integer literals should not be used in mode expression; use symbolic constants instead",
+              "Integer literals should not be used in mode expression.",
               e.loc,
               {
-                suggestion:
-                  "Replace integer literals with symbolic flag constants",
+                suggestion,
               },
             ),
           );

--- a/src/detectors/builtin/suspiciousMessageMode.ts
+++ b/src/detectors/builtin/suspiciousMessageMode.ts
@@ -115,7 +115,7 @@ export class SuspiciousMessageMode extends ASTDetector {
           }
           warnings.push(
             this.makeWarning(
-              "Integer literals should not be used in mode expression.",
+              "Integer literals should not be used in mode expression",
               e.loc,
               {
                 suggestion,

--- a/test/detectors/SuspiciousMessageMode.expected.out
+++ b/test/detectors/SuspiciousMessageMode.expected.out
@@ -16,13 +16,13 @@ test/detectors/SuspiciousMessageMode.tact:25:19:
 Help: Use the '|' operator (bitwise OR) to combine flags
 See: https://nowarp.io/tools/misti/docs/detectors/SuspiciousMessageMode
 
-[MEDIUM] SuspiciousMessageMode: Integer literals should not be used in mode expression; use symbolic constants instead
+[MEDIUM] SuspiciousMessageMode: Integer literals should not be used in mode expression.
 test/detectors/SuspiciousMessageMode.tact:34:19:
   33 |             value: 0,
 > 34 |             mode: 64 // Bad: Integer literal instead of symbolic constant 
                          ^
   35 |         });
-Help: Replace integer literals with symbolic flag constants
+Help: Replace `64` with `SendRemainingValue`
 See: https://nowarp.io/tools/misti/docs/detectors/SuspiciousMessageMode
 
 [MEDIUM] SuspiciousMessageMode: Mode expression should only contain the '|' operator
@@ -43,13 +43,13 @@ test/detectors/SuspiciousMessageMode.tact:52:40:
 Help: Use each flag at most once in the mode expression
 See: https://nowarp.io/tools/misti/docs/detectors/SuspiciousMessageMode
 
-[MEDIUM] SuspiciousMessageMode: Integer literals should not be used in mode expression; use symbolic constants instead
+[MEDIUM] SuspiciousMessageMode: Integer literals should not be used in mode expression.
 test/detectors/SuspiciousMessageMode.tact:52:61:
   51 |             value: 0,
 > 52 |             mode: SendRemainingValue + SendRemainingValue + 64 // Bad: Duplicate flags, '+' operator, integer literal 
                                                                    ^
   53 |         });
-Help: Replace integer literals with symbolic flag constants
+Help: Replace `64` with `SendRemainingValue`
 See: https://nowarp.io/tools/misti/docs/detectors/SuspiciousMessageMode
 
 [MEDIUM] SuspiciousMessageMode: Mode expression should only contain the '|' operator

--- a/test/detectors/SuspiciousMessageMode.expected.out
+++ b/test/detectors/SuspiciousMessageMode.expected.out
@@ -43,7 +43,7 @@ test/detectors/SuspiciousMessageMode.tact:52:40:
 Help: Use each flag at most once in the mode expression
 See: https://nowarp.io/tools/misti/docs/detectors/SuspiciousMessageMode
 
-[MEDIUM] SuspiciousMessageMode: Integer literals should not be used in mode expression.
+[MEDIUM] SuspiciousMessageMode: Integer literals should not be used in mode expression
 test/detectors/SuspiciousMessageMode.tact:52:61:
   51 |             value: 0,
 > 52 |             mode: SendRemainingValue + SendRemainingValue + 64 // Bad: Duplicate flags, '+' operator, integer literal 

--- a/test/detectors/SuspiciousMessageMode.expected.out
+++ b/test/detectors/SuspiciousMessageMode.expected.out
@@ -16,7 +16,7 @@ test/detectors/SuspiciousMessageMode.tact:25:19:
 Help: Use the '|' operator (bitwise OR) to combine flags
 See: https://nowarp.io/tools/misti/docs/detectors/SuspiciousMessageMode
 
-[MEDIUM] SuspiciousMessageMode: Integer literals should not be used in mode expression.
+[MEDIUM] SuspiciousMessageMode: Integer literals should not be used in mode expression
 test/detectors/SuspiciousMessageMode.tact:34:19:
   33 |             value: 0,
 > 34 |             mode: 64 // Bad: Integer literal instead of symbolic constant 


### PR DESCRIPTION

Closes #196 

- [ ] I have updated `CHANGELOG.md`
- [x] I have added tests to demonstrate the contribution is correctly implemented
- [x] No test failures were reported when running `yarn test-all`
- [x] I did not do unrelated and/or undiscussed refactorings

