### PR TITLE
WIP: Detector `properExitCodeUsage`

### DIFF
--- a/src/detectors/builtin/properExitCodeUsage.ts
+++ b/src/detectors/builtin/properExitCodeUsage.ts
@@ -1,0 +1,113 @@
+import { CompilationUnit, CFG } from "../../internals/ir";
+import { WorklistSolver } from "../../internals/solver";
+import { MistiTactWarning, Severity } from "../../internals/warnings";
+import { DataflowDetector } from "../detector";
+import { SrcInfo } from "@tact-lang/compiler/dist/grammar/ast";
+
+const RESERVED_RANGE = { min: 0, max: 127 };
+const TACT_RANGE = { min: 128, max: 255 };
+const DEV_RANGE = { min: 256, max: 65535 };
+
+export class ProperExitCodeUsage extends DataflowDetector {
+  severity = Severity.HIGH;
+
+  async check(cu: CompilationUnit): Promise<MistiTactWarning[]> {
+    const warnings: MistiTactWarning[] = [];
+    cu.forEachCFG((cfg: CFG) => {
+      const lattice = new ExitCodeLattice();
+      const transfer = new ExitCodeTransfer();
+      const solver = new WorklistSolver(cu, cfg, transfer, lattice, "forward");
+      const results = solver.solve();
+      results.getStates().forEach((state: ExitCodeState) => {
+        state.improperExitCodes.forEach((loc, exitCode) => {
+          warnings.push(
+            this.makeWarning(`Improper exit code used: ${exitCode}.`, loc, {
+              extraDescription:
+                "Use exit codes within the allowed range (256-65535, excluding 128).",
+              suggestion: "Adjust exit codes accordingly.",
+            }),
+          );
+        });
+      });
+    });
+    return warnings;
+  }
+}
+
+type ExitCodeState = {
+  improperExitCodes: Map<number, SrcInfo>;
+};
+
+class ExitCodeLattice {
+  bottom(): ExitCodeState {
+    return { improperExitCodes: new Map<number, SrcInfo>() };
+  }
+
+  join(a: ExitCodeState, b: ExitCodeState): ExitCodeState {
+    const improperExitCodes = new Map([
+      ...a.improperExitCodes,
+      ...b.improperExitCodes,
+    ]);
+    return { improperExitCodes };
+  }
+
+  leq(a: ExitCodeState, b: ExitCodeState): boolean {
+    return Array.from(a.improperExitCodes.keys()).every((key) =>
+      b.improperExitCodes.has(key),
+    );
+  }
+}
+
+class ExitCodeTransfer {
+  transfer(inState: ExitCodeState, _node: any, stmt: any): ExitCodeState {
+    const outState = { improperExitCodes: new Map(inState.improperExitCodes) };
+
+    if (
+      stmt.kind === "statement_expression" &&
+      stmt.expression.kind === "static_call"
+    ) {
+      const staticCall = stmt.expression;
+      if (staticCall.function.text === "nativeThrowUnless") {
+        const [exitCodeExpr] = staticCall.args;
+        const exitCode = this.evaluateExitCodeExpression(exitCodeExpr);
+        if (exitCode !== undefined) {
+          this.checkExitCode(outState, exitCode, stmt.loc);
+        }
+      }
+    }
+    return outState;
+  }
+
+  private evaluateExitCodeExpression(expr: any): number | undefined {
+    if (expr.kind === "number") {
+      return expr.value;
+    } else if (expr.kind === "field_access" && expr.aggregate.text === "self") {
+      const fieldName = expr.field.text;
+      const knownExitCodes: Record<string, number> = {
+        InvalidExitCode: 128,
+        ExcessiveExitCode: 70000,
+        ValidExitCode: 256,
+        NearMaxExitCode: 65535,
+      };
+      const value = knownExitCodes[fieldName];
+      if (value !== undefined) {
+        return value;
+      }
+    }
+    return undefined;
+  }
+
+  private checkExitCode(
+    outState: ExitCodeState,
+    exitCode: number,
+    loc: SrcInfo,
+  ): void {
+    if (
+      (exitCode >= RESERVED_RANGE.min && exitCode <= RESERVED_RANGE.max) ||
+      exitCode === TACT_RANGE.min ||
+      exitCode > DEV_RANGE.max
+    ) {
+      outState.improperExitCodes.set(exitCode, loc);
+    }
+  }
+}

--- a/src/detectors/detector.ts
+++ b/src/detectors/detector.ts
@@ -385,6 +385,13 @@ export const BuiltInDetectors: Record<string, DetectorEntry> = {
       ),
     enabledByDefault: true,
   },
+  ProperExitCodeUsage: {
+    loader: (ctx: MistiContext) =>
+      import("./builtin/properExitCodeUsage").then(
+        (module) => new module.ProperExitCodeUsage(ctx),
+      ),
+    enabledByDefault: true,
+  },
 };
 
 /**

--- a/test/detectors/ProperExitCodeUsage.expected.out
+++ b/test/detectors/ProperExitCodeUsage.expected.out
@@ -1,0 +1,19 @@
+[HIGH] ProperExitCodeUsage: Improper exit code used: 128.
+test/detectors/ProperExitCodeUsage.tact:11:9:
+  10 |     receive("Bad Example!") {
+> 11 |         nativeThrowUnless(self.InvalidExitCode, sender() == self.owner);
+               ^
+  12 |     }
+Use exit codes within the allowed range (256-65535, excluding 128).
+Help: Adjust exit codes accordingly.
+See: https://nowarp.io/tools/misti/docs/detectors/ProperExitCodeUsage
+
+[HIGH] ProperExitCodeUsage: Improper exit code used: 70000.
+test/detectors/ProperExitCodeUsage.tact:25:9:
+  24 |     receive("Bad Example!") {
+> 25 |         nativeThrowUnless(self.ExcessiveExitCode, sender() == self.owner);
+               ^
+  26 |     }
+Use exit codes within the allowed range (256-65535, excluding 128).
+Help: Adjust exit codes accordingly.
+See: https://nowarp.io/tools/misti/docs/detectors/ProperExitCodeUsage

--- a/test/detectors/ProperExitCodeUsage.tact
+++ b/test/detectors/ProperExitCodeUsage.tact
@@ -1,0 +1,55 @@
+// Bad example - using reserved exit code 128, which should trigger the detector warning
+contract BadExitCodeContract {
+    const InvalidExitCode: Int = 128;
+    owner: Address;
+
+    init(ownerAddress: Address) {
+        self.owner = ownerAddress;
+    }
+
+    receive("Bad Example!") {
+        nativeThrowUnless(self.InvalidExitCode, sender() == self.owner);
+    }
+}
+
+// Another bad example - using an exit code above the allowed range, which should also trigger a warning
+contract ExcessiveExitCodeContract {
+    const ExcessiveExitCode: Int = 70000;
+    owner: Address;
+
+    init(ownerAddress: Address) {
+        self.owner = ownerAddress;
+    }
+
+    receive("Bad Example!") {
+        nativeThrowUnless(self.ExcessiveExitCode, sender() == self.owner);
+    }
+}
+
+// Good example - using a valid developer-defined exit code within the allowed range
+contract ValidExitCodeContract {
+    const ValidExitCode: Int = 256;
+    owner: Address;
+
+    init(ownerAddress: Address) {
+        self.owner = ownerAddress;
+    }
+
+    receive("Good example") {
+        nativeThrowUnless(self.ValidExitCode, sender() == self.owner);
+    }
+}
+
+// Another good example - an exit code within the range, near the upper limit
+contract UpperLimitExitCodeContract {
+    const NearMaxExitCode: Int = 65535;
+    owner: Address;
+
+    init(ownerAddress: Address) {
+        self.owner = ownerAddress;
+    }
+
+    receive("upperLimitFunc") {
+        nativeThrowUnless(self.NearMaxExitCode, sender() == self.owner);
+    }
+}


### PR DESCRIPTION
Closes #103 

- [ ] I have updated `CHANGELOG.md`
- [x] I have added tests to demonstrate the contribution is correctly implemented
- [x] No test failures were reported when running `yarn test-all`
- [x] I did not do unrelated and/or undiscussed refactorings

