### PR TITLE
fix(cellBounds): Infinite recursion due to incorrect `leq` impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BranchDuplicate`: False negative in `else-if` clauses: Issue [#258](https://github.com/nowarp/misti/issues/258)
 - `UnboundMap`: False positive: Issue [#262](https://github.com/nowarp/misti/issues/262)
 - Internal Errors Printed to `stderr` Instead of JSON Output: Issue [#263](https://github.com/nowarp/misti/issues/263)
+- `CellBounds`: Infinite recursion: PR [#272](https://github.com/nowarp/misti/pull/272)
 
 ## [0.6.2] - 2024-12-25
 

--- a/src/internals/tact/util.ts
+++ b/src/internals/tact/util.ts
@@ -240,13 +240,13 @@ export class SrcInfoSet<T> {
 
   has(item: [T, SrcInfo]): boolean {
     return this.items.some((existingItem) =>
-      this.equals(existingItem[1], item[1]),
+      srcInfoEq(existingItem[1], item[1]),
     );
   }
 
   delete(item: [T, SrcInfo]): boolean {
     const index = this.items.findIndex((existingItem) =>
-      this.equals(existingItem[1], item[1]),
+      srcInfoEq(existingItem[1], item[1]),
     );
     if (index !== -1) {
       this.items.splice(index, 1);
@@ -257,27 +257,6 @@ export class SrcInfoSet<T> {
 
   extract(): [T, SrcInfo][] {
     return this.items.slice();
-  }
-
-  private equals(srcInfo1: SrcInfo, srcInfo2: SrcInfo): boolean {
-    return (
-      srcInfo1.file === srcInfo2.file &&
-      srcInfo1.contents === srcInfo2.contents &&
-      this.compareIntervals(srcInfo1.interval, srcInfo2.interval) &&
-      srcInfo1.origin === srcInfo2.origin
-    );
-  }
-
-  private compareIntervals(
-    interval1: RawInterval,
-    interval2: RawInterval,
-  ): boolean {
-    return (
-      interval1.sourceString === interval2.sourceString &&
-      interval1.startIdx === interval2.startIdx &&
-      interval1.endIdx === interval2.endIdx &&
-      interval1.contents === interval2.contents
-    );
   }
 }
 
@@ -578,5 +557,23 @@ export function isSendCall(expr: AstExpression): boolean {
     (expr.kind === "method_call" &&
       isSelf(expr.self) &&
       SEND_METHODS.includes(expr.method.text))
+  );
+}
+
+export function srcInfoEq(a: SrcInfo, b: SrcInfo): boolean {
+  return (
+    a.file === b.file &&
+    a.contents === b.contents &&
+    a.origin === b.origin &&
+    intervalsEq(a.interval, b.interval)
+  );
+}
+
+export function intervalsEq(a: RawInterval, b: RawInterval): boolean {
+  return (
+    a.sourceString === b.sourceString &&
+    a.startIdx === b.startIdx &&
+    a.endIdx === b.endIdx &&
+    a.contents === b.contents
   );
 }

--- a/src/internals/util.ts
+++ b/src/internals/util.ts
@@ -9,21 +9,32 @@ import path from "path";
 
 export const mergeSets = <T>(lhs: Set<T>, rhs: Set<T>): Set<T> =>
   new Set([...lhs, ...rhs]);
-export const isSetSubsetOf = <T>(lhs: Set<T>, rhs: Set<T>): boolean =>
-  [...lhs].every((elem) => rhs.has(elem));
+export const isSetSubsetOf = <T>(
+  lhs: Set<T>,
+  rhs: Set<T>,
+  eq: (a: T, b: T) => boolean = (a, b) => a === b,
+): boolean =>
+  [...lhs].every((elem) => [...rhs].some((rElem) => eq(elem, rElem)));
 export const intersectSets = <T>(setA: Set<T>, setB: Set<T>): Set<T> =>
   new Set([...setA].filter((item) => setB.has(item)));
 
 export const mergeLists = <T>(lhs: T[], rhs: T[]): T[] => [...lhs, ...rhs];
-export const isListSubsetOf = <T>(lhs: T[], rhs: T[]): boolean =>
-  lhs.every((elem) => rhs.includes(elem));
+export const isListSubsetOf = <T>(
+  lhs: T[],
+  rhs: T[],
+  eq: (a: T, b: T) => boolean = (a, b) => a === b,
+): boolean => lhs.every((elem) => rhs.some((rElem) => eq(elem, rElem)));
 export const intersectLists = <T>(l1: T[], l2: T[]): T[] =>
   l1.filter((element) => l2.includes(element));
 
 export const mergeMaps = <K, V>(lhs: Map<K, V>, rhs: Map<K, V>): Map<K, V> =>
   new Map([...lhs, ...rhs]);
-export const isMapSubsetOf = <K, V>(lhs: Map<K, V>, rhs: Map<K, V>): boolean =>
-  [...lhs].every(([key, value]) => rhs.has(key) && rhs.get(key) === value);
+export const isMapSubsetOf = <K, V>(
+  lhs: Map<K, V>,
+  rhs: Map<K, V>,
+  eq: (a: V, b: V) => boolean = (a, b) => a === b,
+): boolean =>
+  [...lhs].every(([key, value]) => rhs.has(key) && eq(value, rhs.get(key)!));
 export const intersectMaps = <K, V>(
   mapA: Map<K, V>,
   mapB: Map<K, V>,

--- a/test/detectors/CellBounds.expected.out
+++ b/test/detectors/CellBounds.expected.out
@@ -1,119 +1,119 @@
 [CRITICAL] CellBounds: Reference count might go below 0
-test/detectors/CellBounds.tact:7:9:
-  6 | fun refs_underflow(c: Cell) {
-> 7 |     let s1 = beginCell()
-              ^
-  8 |                .storeRef(c)
-The possible number of references stored (1) is less than loaded (2)
-Help: Remove extra .loadRef operations or store more refs first
-See: https://nowarp.io/tools/misti/docs/detectors/CellBounds
-
-[CRITICAL] CellBounds: Reference count might go below 0
-test/detectors/CellBounds.tact:12:9:
-  11 |     let ref1 = s1.loadRef(); // OK
-> 12 |     let ref2 = s1.loadRef(); // Bad: Cell Underflow
+test/detectors/CellBounds.tact:11:9:
+  10 | fun refs_underflow(c: Cell) {
+> 11 |     let s1 = beginCell()
                ^
-  13 | 
+  12 |                .storeRef(c)
 The possible number of references stored (1) is less than loaded (2)
 Help: Remove extra .loadRef operations or store more refs first
 See: https://nowarp.io/tools/misti/docs/detectors/CellBounds
 
 [CRITICAL] CellBounds: Reference count might go below 0
-test/detectors/CellBounds.tact:14:5:
-  13 | 
-> 14 |     beginCell() // Bad: Cell Underflow
+test/detectors/CellBounds.tact:16:9:
+  15 |     let ref1 = s1.loadRef(); // OK
+> 16 |     let ref2 = s1.loadRef(); // Bad: Cell Underflow
+               ^
+  17 | 
+The possible number of references stored (1) is less than loaded (2)
+Help: Remove extra .loadRef operations or store more refs first
+See: https://nowarp.io/tools/misti/docs/detectors/CellBounds
+
+[CRITICAL] CellBounds: Reference count might go below 0
+test/detectors/CellBounds.tact:18:5:
+  17 | 
+> 18 |     beginCell() // Bad: Cell Underflow
            ^
-  15 |       .endCell()
+  19 |       .endCell()
 The possible number of references stored (0) is less than loaded (1)
 Help: Remove extra .loadRef operations or store more refs first
 See: https://nowarp.io/tools/misti/docs/detectors/CellBounds
 
 [CRITICAL] CellBounds: Reference count might go below 0
-test/detectors/CellBounds.tact:21:9:
-  20 |     let st1 = S {a: 1 , b: 2};
-> 21 |     let c1 = st1.toCell().asSlice().loadRef(); // Bad: Cell Underflow
+test/detectors/CellBounds.tact:25:9:
+  24 |     let st1 = S {a: 1 , b: 2};
+> 25 |     let c1 = st1.toCell().asSlice().loadRef(); // Bad: Cell Underflow
                ^
-  22 |     st1.toCell().asSlice().loadRef(); // Bad: Cell Underflow
+  26 |     st1.toCell().asSlice().loadRef(); // Bad: Cell Underflow
 The possible number of references stored (0) is less than loaded (2)
 Help: Remove extra .loadRef operations or store more refs first
 See: https://nowarp.io/tools/misti/docs/detectors/CellBounds
 
 [CRITICAL] CellBounds: Reference count might go below 0
-test/detectors/CellBounds.tact:22:5:
-  21 |     let c1 = st1.toCell().asSlice().loadRef(); // Bad: Cell Underflow
-> 22 |     st1.toCell().asSlice().loadRef(); // Bad: Cell Underflow
+test/detectors/CellBounds.tact:26:5:
+  25 |     let c1 = st1.toCell().asSlice().loadRef(); // Bad: Cell Underflow
+> 26 |     st1.toCell().asSlice().loadRef(); // Bad: Cell Underflow
            ^
-  23 | }
+  27 | }
 The possible number of references stored (0) is less than loaded (1)
 Help: Remove extra .loadRef operations or store more refs first
 See: https://nowarp.io/tools/misti/docs/detectors/CellBounds
 
 [CRITICAL] CellBounds: Too many references stored in cell
-test/detectors/CellBounds.tact:32:9:
-  31 |                .storeRef(c); // OK: Builder storing 4 references
-> 32 |     let c1 = beginCell() // Bad: We got 5 references
+test/detectors/CellBounds.tact:36:9:
+  35 |                .storeRef(c); // OK: Builder storing 4 references
+> 36 |     let c1 = beginCell() // Bad: We got 5 references
                ^
-  33 |                .storeBuilder(b1)
+  37 |                .storeBuilder(b1)
 The minimum number of references stored (5) exceeds the maximum allowed (4)
 Help: Split your data across multiple cells - a single cell cannot store more than 4 references
 See: https://nowarp.io/tools/misti/docs/detectors/CellBounds
 
 [CRITICAL] CellBounds: Too many references stored in cell
-test/detectors/CellBounds.tact:37:9:
-  36 | 
-> 37 |     let c2 = // Bad: 4+ refs
+test/detectors/CellBounds.tact:41:9:
+  40 | 
+> 41 |     let c2 = // Bad: 4+ refs
                ^
-  38 |     beginCell()
+  42 |     beginCell()
 The minimum number of references stored (5) exceeds the maximum allowed (4)
 Help: Split your data across multiple cells - a single cell cannot store more than 4 references
 See: https://nowarp.io/tools/misti/docs/detectors/CellBounds
 
 [CRITICAL] CellBounds: Too many references stored in cell
-test/detectors/CellBounds.tact:51:4:
-  50 |    b2 = b2.storeRef(c);
-> 51 |    b2 = b2.storeRef(c); // Bad: 4+ refs
+test/detectors/CellBounds.tact:55:4:
+  54 |    b2 = b2.storeRef(c);
+> 55 |    b2 = b2.storeRef(c); // Bad: 4+ refs
           ^
-  52 |    let c3 = b2.endCell(); // Bad: 4+ refs
+  56 |    let c3 = b2.endCell(); // Bad: 4+ refs
 The minimum number of references stored (5) exceeds the maximum allowed (4)
 Help: Split your data across multiple cells - a single cell cannot store more than 4 references
 See: https://nowarp.io/tools/misti/docs/detectors/CellBounds
 
 [CRITICAL] CellBounds: Too many references stored in cell
-test/detectors/CellBounds.tact:54:8:
-  53 | 
-> 54 |    let b3 = b2;
+test/detectors/CellBounds.tact:58:8:
+  57 | 
+> 58 |    let b3 = b2;
               ^
-  55 |    let c4 = b3.endCell(); // Bad: 4+ refs
+  59 |    let c4 = b3.endCell(); // Bad: 4+ refs
 The minimum number of references stored (5) exceeds the maximum allowed (4)
 Help: Split your data across multiple cells - a single cell cannot store more than 4 references
 See: https://nowarp.io/tools/misti/docs/detectors/CellBounds
 
 [CRITICAL] CellBounds: Data size exceeds cell capacity
-test/detectors/CellBounds.tact:63:5:
-  62 |     b1 = b1.storeInt(42, 256+1);
-> 63 |     b1 = b1.storeInt(42, 257); // Bad: 1023+ bits
+test/detectors/CellBounds.tact:67:5:
+  66 |     b1 = b1.storeInt(42, 256+1);
+> 67 |     b1 = b1.storeInt(42, 257); // Bad: 1023+ bits
            ^
-  64 |     let c1 = b1.endCell(); // Bad: 1023+ bits
+  68 |     let c1 = b1.endCell(); // Bad: 1023+ bits
 The minimum data size stored (1028 bits) exceeds the maximum allowed (1023 bits)
 Help: Split your data across multiple cells - a single cell cannot store more than 1023 bits
 See: https://nowarp.io/tools/misti/docs/detectors/CellBounds
 
 [CRITICAL] CellBounds: Data size exceeds cell capacity
-test/detectors/CellBounds.tact:71:5:
-  70 |            .storeInt(1, 210); // Total size: 981
-> 71 |     b2 = b2.storeCoins(40000000000); // Bad: 44 + 981 = 1025 => overflow
+test/detectors/CellBounds.tact:75:5:
+  74 |            .storeInt(1, 210); // Total size: 981
+> 75 |     b2 = b2.storeCoins(40000000000); // Bad: 44 + 981 = 1025 => overflow
            ^
-  72 |     c1 = b2.endCell(); // Bad
+  76 |     c1 = b2.endCell(); // Bad
 The minimum data size stored (1025 bits) exceeds the maximum allowed (1023 bits)
 Help: Split your data across multiple cells - a single cell cannot store more than 1023 bits
 See: https://nowarp.io/tools/misti/docs/detectors/CellBounds
 
 [CRITICAL] CellBounds: Data size exceeds cell capacity
-test/detectors/CellBounds.tact:80:5:
-  79 |     let b3 = beginCell();
-> 80 |     b3 = b3.storeBuilder(b_1000_bits) // Bad: 1025 bits
+test/detectors/CellBounds.tact:84:5:
+  83 |     let b3 = beginCell();
+> 84 |     b3 = b3.storeBuilder(b_1000_bits) // Bad: 1025 bits
            ^
-  81 |            .storeInt(1, 25);
+  85 |            .storeInt(1, 25);
 The minimum data size stored (1025 bits) exceeds the maximum allowed (1023 bits)
 Help: Split your data across multiple cells - a single cell cannot store more than 1023 bits
 See: https://nowarp.io/tools/misti/docs/detectors/CellBounds

--- a/test/detectors/CellBounds.tact
+++ b/test/detectors/CellBounds.tact
@@ -1,3 +1,7 @@
+// Test for: https://github.com/nowarp/misti/issues/270
+struct R { a: Int; }
+fun f() { let r = R { a: 0 }; repeat (1) { } }
+
 struct S {
     a: Int;
     b: Int;


### PR DESCRIPTION
Fixes #270

- [x] I have updated `CHANGELOG.md`
- [x] I have added tests to demonstrate the contribution is correctly implemented
- [x] No test failures were reported when running `yarn test-all`
- [x] I did not do unrelated and/or undiscussed refactorings

