### PR TITLE
fix(cellBounds): `Object.prototype` on `.toString` method in Tact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Callgraph: Incorrect handling of getter methods: PR [#282](https://github.com/nowarp/misti/pull/282)
 - `ArgCopyMutation`: Incorrect handling of `return` in traits: Issue [#290](https://github.com/nowarp/misti/issues/290)
 - `SendInLoop`: Remove redundant error logs when accessing patterns like `self.<map_field>.set()`
+- `CellBounds`: Accessing property of `Object.prototype` on `.toString` method in Tact: Issue [#317](https://github.com/nowarp/misti/issues/317)
 
 ## [0.6.2] - 2024-12-25
 

--- a/src/detectors/builtin/cellBounds.ts
+++ b/src/detectors/builtin/cellBounds.ts
@@ -414,7 +414,12 @@ class CellUnderflowTransfer implements Transfer<CellUnderflowState> {
       fromCell: { from: [VariableKind.Cell], to: VariableKind.StructMessage },
       fromSlice: { from: [VariableKind.Slice], to: VariableKind.StructMessage },
     };
-    const transform = typeTransforms[methodName];
+    const transform = Object.prototype.hasOwnProperty.call(
+      typeTransforms,
+      methodName,
+    )
+      ? typeTransforms[methodName]
+      : undefined;
     return transform && transform.from.includes(currentKind)
       ? transform.to
       : currentKind;


### PR DESCRIPTION
Closes #317

- [ ] I have updated `CHANGELOG.md`
- [ ] I have added tests to demonstrate the contribution is correctly implemented
- [ ] No test failures were reported when running `yarn test-all`
- [ ] I did not do unrelated and/or undiscussed refactorings

