### PR TITLE
Don't print error messages when `-o "json"` is set

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,7 +53,7 @@ module.exports = {
   // Suppress `no-console` for specific files
   "overrides": [
     {
-      "files": ["src/internals/logger.ts", "src/createDetector.ts", "src/main.ts", "test/**"],
+      "files": ["src/internals/logger.ts", "src/createDetector.ts", "src/main.ts", "test/**", "src/cli/cli.ts"],
       "rules": {
         "no-console": "off"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ArgCopyMutation`: Incorrect handling of `return` in traits: Issue [#290](https://github.com/nowarp/misti/issues/290)
 - `SendInLoop`: Remove redundant error logs when accessing patterns like `self.<map_field>.set()`
 - `CellBounds`: Accessing property of `Object.prototype` on `.toString` method in Tact: PR [#318](https://github.com/nowarp/misti/pull/318)
+- Don't print error messages when `-o "json"` is set: PR [#2320](https://github.com/nowarp/misti/pull/320)
 
 ## [0.6.2] - 2024-12-25
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -122,13 +122,14 @@ function handleOutputToConsole(
   const text = resultToString(result, outputFormat);
   switch (result.kind) {
     case "warnings":
-      logger.warn(text);
+      outputFormat === "json" ? console.warn(text) : logger.warn(text);
       break;
     case "error":
-      logger.error(text);
+      outputFormat === "json" ? console.error(text) : logger.error(text);
       break;
     case "tool":
     case "ok":
+      outputFormat === "json" ? console.log(text) : logger.error(text);
       logger.info(text);
       break;
     default:

--- a/src/internals/logger.ts
+++ b/src/internals/logger.ts
@@ -52,7 +52,7 @@ export class Logger {
   ): LogFunction {
     return (msg: string) => {
       if (this.saveJson) this.jsonLogs.get(level)?.push(msg);
-      baseFunc(msg);
+      else baseFunc(msg);
     };
   }
 


### PR DESCRIPTION
Closes #295

- [ ] I have updated `CHANGELOG.md`
- [ ] I have added tests to demonstrate the contribution is correctly implemented
- [x] No test failures were reported when running `yarn test-all`
- [x] I did not do unrelated and/or undiscussed refactorings

