### PR TITLE
CI: Add check for `[object Object]` in expected outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,13 @@ jobs:
         output: /tmp/lychee.txt
         fail: true
 
+    - name: Check for [object Object] in test output files
+      run: |
+        if grep -r "\[object Object\]" test/**/*.out; then
+          echo "Found [object Object] in test output files"
+          exit 1
+        fi
+
     - name: Build
       run: |
         yarn gen


### PR DESCRIPTION
Will help to handle regressions like https://github.com/nowarp/misti/commit/e9bf1a4bbf1fee3c68597c2267ec679d2c3ca824