### PR TITLE
fix(warnings): Use relative paths in `plain` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Severity filter for detectors (optimization): Issue [#358](https://github.com/nowarp/misti/issues/358)
+- Relative paths in displayed warnings: PR [#361](https://github.com/nowarp/misti/pull/361)
 
 ## [0.8.0] - 2025-04-08
 

--- a/src/internals/util.ts
+++ b/src/internals/util.ts
@@ -84,5 +84,5 @@ export function isTest(): boolean {
  * Creates a relative path from the `process.cwd()`.
  */
 export function makeRelativePath(p: string): string {
- return path.normalize(path.relative(process.cwd(), p));
+  return path.normalize(path.relative(process.cwd(), p));
 }

--- a/src/internals/util.ts
+++ b/src/internals/util.ts
@@ -79,3 +79,10 @@ export function isBrowser(): boolean {
 export function isTest(): boolean {
   return process.env.JEST_WORKER_ID !== undefined;
 }
+
+/**
+ * Creates a relative path from the `process.cwd()`.
+ */
+export function makeRelativePath(p: string): string {
+ return path.normalize(path.relative(process.cwd(), p));
+}

--- a/src/internals/warnings.ts
+++ b/src/internals/warnings.ts
@@ -3,7 +3,7 @@ import { InternalException } from "./exceptions";
 import { QuickFix } from "./quickfix";
 import { quickFixToString } from "./quickfix";
 import { SrcInfo } from "./tact/imports";
-import { isTest, unreachable } from "./util";
+import { isTest, makeRelativePath, unreachable } from "./util";
 import path from "path";
 
 /**
@@ -148,7 +148,7 @@ export function makeWarningLocation(loc: SrcInfo): WarningLocation {
   const code = loc.interval.getLineAndColumnMessage();
   const file = loc.file
     ? isTest()
-      ? path.normalize(path.relative(process.cwd(), loc.file))
+      ? makeRelativePath(loc.file)
       : path.normalize(loc.file)
     : "<no file>";
   return { file, line: lc.lineNum, column: lc.colNum, code };
@@ -158,7 +158,7 @@ export function makeWarningLocation(loc: SrcInfo): WarningLocation {
  * Converts SrcInfo to the string representation shown to the user.
  */
 export function warningLocationToString(wl: WarningLocation): string {
-  return `${wl.file}:${wl.line}:${wl.column}:\n${wl.code}`;
+  return `${makeRelativePath(wl.file)}:${wl.line}:${wl.column}:\n${wl.code}`;
 }
 
 export function makeWarning(


### PR DESCRIPTION
Closes #359

- [x] I have updated `CHANGELOG.md`
- [x] I have added tests to demonstrate the contribution is correctly implemented
- [x] No test failures were reported when running `yarn test-all`
- [x] I did not do unrelated and/or undiscussed refactorings

