### PR TITLE
fix(logger): Cannot execute Misti in browser environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `No errors found` gets printed twice: Issue [#375](https://github.com/nowarp/misti/issues/375)
+- Cannot execute Misti in browser environment: PR [#377](https://github.com/nowarp/misti/pull/377)
 
 ## [0.8.1] - 2025-04-19
 


### PR DESCRIPTION
Closes #376

- [x] I have updated `CHANGELOG.md`
- [ ] I have added tests to demonstrate the contribution is correctly implemented
- [ ] No test failures were reported when running `yarn test-all`
- [x] I did not do unrelated and/or undiscussed refactorings

