### PR TITLE
Improve SARIF support

### DIFF
--- a/src/internals/warnings.ts
+++ b/src/internals/warnings.ts
@@ -5,6 +5,7 @@ import { QuickFix } from "./quickfix";
 import { quickFixToString } from "./quickfix";
 import { SrcInfo } from "./tact/imports";
 import { ansi, isTest, makeRelativePath, unreachable } from "./util";
+import fs from "fs";
 import path from "path";
 
 /**
@@ -319,6 +320,26 @@ export interface SarifReport {
         }>;
       };
     };
+    automationDetails?: {
+      id: string;
+    };
+    invocations: Array<{
+      commandLine?: string;
+      arguments?: string[];
+      responseFiles?: Array<{
+        uri: string;
+        contents?: {
+          text: string;
+        };
+      }>;
+      startTimeUtc?: string;
+      endTimeUtc?: string;
+      exitCode?: number;
+      executionSuccessful: boolean;
+      workingDirectory?: {
+        uri: string;
+      };
+    }>;
     results: SarifResult[];
   }>;
 }
@@ -334,8 +355,8 @@ function severityToSarifLevel(
     case Severity.HIGH:
       return "error";
     case Severity.MEDIUM:
-      return "warning";
     case Severity.LOW:
+      return "warning";
     case Severity.INFO:
       return "note";
     default:
@@ -344,9 +365,71 @@ function severityToSarifLevel(
 }
 
 /**
+ * Finds the git repository root by walking up the directory tree looking for .git folder.
+ * @param startPath The path to start searching from (file or directory)
+ * @returns The git repository root path or null if not found
+ */
+function findGitRepositoryRoot(startPath: string): string | null {
+  let currentDir = path.isAbsolute(startPath)
+    ? fs.statSync(startPath).isDirectory()
+      ? startPath
+      : path.dirname(startPath)
+    : path.resolve(startPath);
+
+  while (currentDir !== path.parse(currentDir).root) {
+    const gitPath = path.join(currentDir, ".git");
+    if (fs.existsSync(gitPath)) {
+      return currentDir;
+    }
+    currentDir = path.dirname(currentDir);
+  }
+  return null;
+}
+
+/**
  * Converts a Warning to SARIF result format.
  */
-export function warningToSarifResult(warning: Warning): SarifResult {
+export function warningToSarifResult(
+  warning: Warning,
+  repositoryRoot?: string,
+): SarifResult {
+  // Convert absolute paths to relative paths for proper repository mapping
+  const getRelativeUri = (filePath: string): string => {
+    // If it's already a relative path, keep it as is
+    if (!path.isAbsolute(filePath)) {
+      return filePath;
+    }
+
+    // Start with the provided repository root
+    let basePath = repositoryRoot;
+
+    // For SARIF, we want the actual git repository root, not just the minimum Tact project path
+    // So if we have a repositoryRoot, try to find a git root that contains it
+    if (basePath) {
+      const gitRoot = findGitRepositoryRoot(basePath);
+      if (gitRoot && basePath.startsWith(gitRoot)) {
+        basePath = gitRoot;
+      }
+    } else {
+      // If no repository root provided, try to find the git repository root from the file path
+      basePath = findGitRepositoryRoot(filePath) || undefined;
+    }
+
+    // Fall back to current working directory if we still don't have a base path
+    if (!basePath) {
+      basePath = process.cwd();
+    }
+
+    // Make the path relative to the base path
+    if (filePath.startsWith(basePath)) {
+      return path.relative(basePath, filePath);
+    }
+
+    // If file is outside the base path, we still try to make it relative
+    // This can happen in test scenarios or complex project setups
+    return path.relative(basePath, filePath);
+  };
+
   const result: SarifResult = {
     ruleId: warning.detectorId,
     level: severityToSarifLevel(warning.severity),
@@ -357,7 +440,7 @@ export function warningToSarifResult(warning: Warning): SarifResult {
       {
         physicalLocation: {
           artifactLocation: {
-            uri: `file://${warning.location.file}`,
+            uri: getRelativeUri(warning.location.file),
           },
           region: {
             startLine: warning.location.line,
@@ -395,7 +478,12 @@ export function warningToSarifResult(warning: Warning): SarifResult {
 /**
  * Converts an array of warnings to a complete SARIF report.
  */
-export function warningsToSarifReport(warnings: Warning[]): SarifReport {
+export function warningsToSarifReport(
+  warnings: Warning[],
+  executionSuccessful: boolean = true,
+  exitCode: number = 0,
+  repositoryRoot?: string,
+): SarifReport {
   // Extract unique detector rules
   const ruleMap = new Map<string, Warning>();
   warnings.forEach((warning) => {
@@ -424,7 +512,9 @@ export function warningsToSarifReport(warnings: Warning[]): SarifReport {
     },
   }));
 
-  const results = warnings.map(warningToSarifResult);
+  const results = warnings.map((warning) =>
+    warningToSarifResult(warning, repositoryRoot),
+  );
 
   return {
     $schema:
@@ -440,6 +530,21 @@ export function warningsToSarifReport(warnings: Warning[]): SarifReport {
             rules,
           },
         },
+        automationDetails: {
+          id: "misti-analysis",
+        },
+        invocations: [
+          {
+            commandLine: process.argv.join(" "),
+            arguments: process.argv.slice(2),
+            startTimeUtc: new Date().toISOString(),
+            exitCode: exitCode,
+            executionSuccessful: executionSuccessful,
+            workingDirectory: {
+              uri: `file://${process.cwd()}`,
+            },
+          },
+        ],
         results,
       },
     ],

--- a/test/sarif.spec.ts
+++ b/test/sarif.spec.ts
@@ -36,12 +36,12 @@ describe("SARIF Output", () => {
       const sarifResult = warningToSarifResult(warning);
 
       expect(sarifResult.ruleId).toBe("TestDetector");
-      expect(sarifResult.level).toBe("error"); // HIGH severity maps to error
+      expect(sarifResult.level).toBe("error");
       expect(sarifResult.message.text).toBe("Test warning description");
       expect(sarifResult.locations).toHaveLength(1);
       expect(
         sarifResult.locations[0].physicalLocation.artifactLocation.uri,
-      ).toBe("file:///test/file.tact");
+      ).toBe("/test/file.tact");
       expect(sarifResult.locations[0].physicalLocation.region.startLine).toBe(
         10,
       );
@@ -73,10 +73,10 @@ describe("SARIF Output", () => {
       expect(warningToSarifResult(highWarning).level).toBe("error");
 
       const mediumWarning = createMockWarning({ severity: Severity.MEDIUM });
-      expect(warningToSarifResult(mediumWarning).level).toBe("error"); // MEDIUM now maps to error for GitHub
+      expect(warningToSarifResult(mediumWarning).level).toBe("warning");
 
       const lowWarning = createMockWarning({ severity: Severity.LOW });
-      expect(warningToSarifResult(lowWarning).level).toBe("warning"); // LOW now maps to warning
+      expect(warningToSarifResult(lowWarning).level).toBe("warning");
 
       const infoWarning = createMockWarning({ severity: Severity.INFO });
       expect(warningToSarifResult(infoWarning).level).toBe("note");


### PR DESCRIPTION
- Use correct relative paths starting from the repository root
- Add the `toolInvocation` section required by GitHub

Example usage: https://github.com/jubnzv/tact-template/pull/1